### PR TITLE
Set the name of the index page to Home

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -65,7 +65,7 @@ markdown_extensions:
 # Navigation
 nav:
   - About:
-    - index.md
+    - Home: index.md
     - How to contribute: 
       - about/contribute/index.md
       - Edit on GitHub: about/contribute/direct_edit.md


### PR DESCRIPTION
Just a quick change so that the name of the landing page is "Home" in a browser tab.
I was getting annoyed... ;-)