### PR TITLE
Replace link to maintainers with link to join issue

### DIFF
--- a/docs/about/contribute/index.md
+++ b/docs/about/contribute/index.md
@@ -11,7 +11,7 @@ Although we encourage everyone to get involved and contribute to the ACCESS-Hive
 
 ## Become a member of the ACCESS-Hive organisation
 
-The ACCESS-Hive organisation is open to any member of the ACCESS community. Furthermore, organisation members have write access to the ACCESS-Hive repository which means they can create branches to contain their modifications instead of creating their own forks. As such, we encourage you to become a member of the organisation by asking one of the [maintainers][access-hive-maintainers] to invite you to join the organisation.
+The ACCESS-Hive organisation is open to any member of the ACCESS community. Furthermore, organisation members have write access to the ACCESS-Hive repository which means they can create branches to contain their modifications instead of creating their own forks. As such, we encourage you to become a member of the organisation by replying to [this issue][issue-179] and ask to be invited to join the organisation.
 
 ## Process to contribute
 
@@ -27,3 +27,5 @@ There are two main ways to contribute to the site:
 [localedit]: local_edit.md
 [standalone_doc]: standalone_doc.md
 [access-hive-maintainers]: https://github.com/orgs/ACCESS-Hive/teams/maintainers
+[issue-179]: https://github.com/ACCESS-Hive/access-hive.github.io/issues/179
+


### PR DESCRIPTION
# ACCESS Community Hive 

Thank you for submitting a pull request to the ACCESS Hive Project. 

## Description

Replace link to maintainers group (which is broken for non-members) with link to issue where people can request to join the organisation.

Fixes #187

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue, e.g. dead links)
- [ ] New link / content

## Checklist:

- [ ] The new content is accessible and located in the appropriate section.
- [ ] My changes do not break navigation and do not generate new warnings
- [ ] I have checked that the links are valid and point to the intended content.
- [ ] I have checked my code/text and corrected any misspellings
- [ ] I have chosen the correct tag for the level of [support provided](https://access-hive.org.au/#support).

Please tag the **reviewers team** in a comment below by prepending an `@` in front of `ACCESS-Hive/reviewers` when ready.
