### PR TITLE
Button to contribution guildelines on the home page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -32,7 +32,7 @@ See the [support page](about/support.md) for details about the support levels: w
 
 ## Contributions
 
-[How to Contribute][HCG]{ .md-button}
+[How to Contribute][HCG]{ .md-button .md-button--primary }
 
 ACCESS-Hive is a community supported site, as such contributions to the ACCESS-Hive site are **encouraged by any member of the community**. Please refer to the [contribution guidelines][HCG] to learn how you can help the ACCESS community build a documentation database useful to everyone.
 


### PR DESCRIPTION
# ACCESS Community Hive 

Thank you for submitting a pull request to the ACCESS Hive Project. 🎉

## Description

The button on the home page "How to contribute" is not visible enough in dark mode. I think the best is simply to render it filled. I've tried changing the .md-button and .md-button--primary classes but it does not work.

I have tried creating my own button but it does not look as nice. The text is blue since it is identified as a link.

Fixes #220


## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue, e.g. dead links)

## Checklist:

- [X] My changes do not break navigation and do not generate new warnings
- [X] I have checked my code/text and corrected any misspellings

Please tag the **reviewers team** in a comment below by prepending an `@` in front of `ACCESS-Hive/reviewers` when ready.
