### PR TITLE
Added to Resources: Aus Reference Climate Data Collection

### DIFF
--- a/docs/model_evaluation/data_catalogs.md
+++ b/docs/model_evaluation/data_catalogs.md
@@ -32,6 +32,15 @@ FLUXNET is an international “network of networks,” tying together regional n
 
 OzFlux is an ecosystem research network set up to provide Australian, New Zealand and global ecosystem modelling communities with consistent observations of energy, carbon and water exchange between the atmosphere and key Australian and New Zealand ecosystems.
 
+## [Australian Community Reference Climate Data Collection][AusRefClimData] {{ recommended }}
+
+{{ community }} [Australian Community Reference Climate Data Collection @ NCI]
+
+This collection is a collaborative effort between the Australian Climate Service (ACS), ARC Centre of Excellence for Climate Extremes (CLEX) and the wider Australian climate research community to re-establish and maintain a reference dataset collection at NCI.
+
+An [intake-esm catalogue](https://github.com/aus-ref-clim-data-nci/acs-replica-intake) is also available to facilitate data access.
+
+
 [NCI-geonetwork]:https://geonetwork.nci.org.au/geonetwork/srv/eng/catalog.search#/home
 [ARE-opus]: https://opus.nci.org.au/display/Help/ARE+User+Guide
 [OZFlux-web]: https://www.ozflux.org.au
@@ -41,3 +50,5 @@ OzFlux is an ecosystem research network set up to provide Australian, New Zealan
 [ILAMB-web]: https://www.ilamb.org/
 [Intake-Ilamb]: https://github.com/nocollier/intake-ilamb
 [ACDG-Catalog]:  https://oneclimate.dmponline.cloud.edu.au/
+[AusRefClimData]: https://aus-ref-clim-data-nci.github.io/aus-ref-clim-data-nci/intro.html
+

--- a/docs/resources/data.md
+++ b/docs/resources/data.md
@@ -1,0 +1,7 @@
+# Data resources
+
+{{ community }} [Australian Community Reference Climate Data Collection @ NCI](https://aus-ref-clim-data-nci.github.io/aus-ref-clim-data-nci/intro.html)
+
+This colllection is a collaborative effort between the Australian Climate Service (ACS), ARC Centre of Excellence for Climate Extremes (CLEX) and the wider Australian climate research community to re-establish and maintain a reference dataset collection at NCI.
+
+An [intake-esm catalogue](https://github.com/aus-ref-clim-data-nci/acs-replica-intake) is also available to facilitate data access.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -109,6 +109,7 @@ nav:
   - Working Groups:
     - working_groups/index.md
   - Resources:
+    - Data: resources/data.md
     - Glossary: resources/glossary.md
     - Policies: resources/policies.md
   - Events: 


### PR DESCRIPTION
Added Australian Community Reference Climate Data Collection @ NCI to "Resources" section, which also includes an intake-esm catalogue.