### PR TITLE
Update freva related links

### DIFF
--- a/docs/model_evaluation/atmosphere.md
+++ b/docs/model_evaluation/atmosphere.md
@@ -7,7 +7,7 @@
 ## [ESMValTool][esmvaltool-web]  {{ recommended }}
 
 [**Documentation**][esmvaltool-doc] |
-[**Tutorial**][esmvaltool-tutorial] | 
+[**Tutorial**][esmvaltool-tutorial] |
 [**Source Code**][esmvaltool-source]
 
 ESMValTool is a community-developed climate model diagnostics and evaluation software package, driven both by computational performance and scientific accuracy and reproducibility. ESMValTool is open to both users and developers, encouraging open exchange of diagnostic source code and evaluation results from the Coupled Model Intercomparison Project CMIP ensemble. For a comprehensive introduction to ESMValTool please visit our documentation page.
@@ -37,7 +37,7 @@ Links to the code repository and documentation for each METplus component are pr
 
 ## [PCMDI Metrics Package (PMP)][pmp-doc]  {{ recommended }}
 
-[**Documentation**][pmp-doc] | 
+[**Documentation**][pmp-doc] |
 [**Sources**][pmp-source]
 
 The PMP is used to provide “quick-look” objective comparisons of Earth System Models (ESMs) with one another and available observations. Results are produced in the context of all model simulations contributed to CMIP6 and earlier CMIP phases. Currently, the comparisons emphasize metrics of large- to global-scale annual cycle and both tropical and extra-tropical modes of variability. Ongoing work in v1.x development branches include established statistics for ENSO, MJO, regional monsoons, and high frequency characteristics of simulated precipitation.
@@ -45,7 +45,7 @@ The PMP is used to provide “quick-look” objective comparisons of Earth Syste
 
 ## [Free Evaluation System Framework (FREVA)][freva-doc] {{ community }}
 
-[**Documentation**][freva-doc] | 
+[**Documentation**][freva-doc] |
 [**Sources**][freva-source]
 
 Freva, the free evaluation system framework, is a data search and analysis platform developed by the atmospheric science community for the atmospheric science community. With help of Freva researchers can:
@@ -117,8 +117,8 @@ Climpred aims to offer a comprehensive set of analysis tools for assessing the q
 [teca-source]: https://github.com/LBL-EESA/TECA
 [teca-tutorials]: https://sourceforge.net/p/teca/TECA_tutorials/HEAD/tree
 
-[freva-doc]: https://freva.gitlab-pages.dkrz.de/evaluation_system/sphinx_docs/index.html
-[freva-source]: https://gitlab.dkrz.de/freva/evaluation_system
+[freva-doc]: https://freva-clint.github.io/freva
+[freva-source]: https://github.com/FREVA-CLINT/freva
 
 [monet-doc]: https://monet-arl.readthedocs.io/en/stable/#
 [monet-tutorial]: https://monet-arl.readthedocs.io/en/stable/tutorial.html


### PR DESCRIPTION


## Description

The freva source and docs have moved to github. This small PR updates the likes herein. 


## Type of change

Please delete options that are not relevant.

- New link / content

## Checklist:

- [x] The new content is accessible and located in the appropriate section
- [x] My changes do not break navigation and do not generate new warnings
- [x] I have checked that the links are valid and point to the intended content
- [x] I have checked my code/text and corrected any misspellings
- [x] I have chosen the correct tag for the level of [support provided](https://access-hive.org.au/#support)

When your pull request is ready please [request a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review). 

Unless there is a specific person you want to review your PR please select the **reviewers team**: `ACCESS-Hive/reviewers`. This ensures the load for reviewing pull requests is shared equitably.
