### PR TITLE
Rearranged HIVE/MED top-level navigation

### DIFF
--- a/docs/model_evaluation/model_evaluation_live_diagnostics.md
+++ b/docs/model_evaluation/model_evaluation_live_diagnostics.md
@@ -1,0 +1,6 @@
+# Live Diagnostics on Gadi
+
+<!-- {% include "call_contribute.md" %} -->
+
+Here, we will describe the tools we provide for "live-diagnostics" of the ACCESS configurations.
+These tools allow you to check model output/progress/failures at specified time steps while your model is running.

--- a/docs/model_evaluation/model_evaluation_on_gadi/model_evaluation_on_gadi_pangeo_cosima.md
+++ b/docs/model_evaluation/model_evaluation_on_gadi/model_evaluation_on_gadi_pangeo_cosima.md
@@ -1,0 +1,5 @@
+# Tutorial for using `pangeo` & COSIMA on Gadi@NCI
+
+{% include "call_contribute.md" %}
+
+https://pangeo.io

--- a/docs/models/running-a-model/getting_started/access_to_gadi_at_nci.md
+++ b/docs/models/running-a-model/getting_started/access_to_gadi_at_nci.md
@@ -1,10 +1,16 @@
+---
+hide:
+  - toc
+---
+
 # <div class="highlight-bg"> Getting Started: Access To Gadi@NCI </div>
 
 Here, we provide you the important information to give you access to the large data that we curate at NCI's storage:
 
 1) [Get an NCI Account](#1-nci-account)  
 2) [Join relevant NCI projects](#2-join-relevant-nci-projects)  
-3) [SSH onto gadi@NCI](#3-accessing-gadinci)  
+3) [Logging in to Gadi@NCI](#3-logging-in-to-gadinci)  
+4) [Computing on Gadi](#4-computing-on-gadi)
 
 ## 1) NCI Account
 
@@ -24,42 +30,46 @@ We recommend you have a chat with your supervisor to identify the relevant proje
 
 To get this conversation started, we list some possibly relevant projects below:
 
-| Project | Project Description |
-|-----------|---------------------------|
-| al33 | ESGF CMIP5 Replication Data |
-| cb20 | ESGF CMIP3 Replication Data |
-| cj50 | COSIMA Model Output Collection |
-| ct11 | ACCESS-NRI Replicated Datasets |
-| fs38 | ESGF CMIP6 Australian Data Publication |
-| ga6 | Modelling the formation of sedimentary basins and continental margins |
-| hh5 | Climate-LIEF Data Storage |
-| ik11 | COSIMA shared working space |
-| iq82 | ACCESS-NRI MED Compute |
-| kj13 | ACCSS-NRI MED Data Dev |
-| m18 | Evolution and dynamics of the Australian lithosphere |
-| nf33 | ACCESS Modelling Workshop - AMOS 2022 |
-| oi10 | ESGF CMIP6 Replication Data |
-| p66 | ACCESS - AOGCM |
-| p73 | ACCESS Model Output Archive (AOGCM) |
-| q97 | Earth dynamics and resources over the last billion years |
-| qu79 | Collaborative REAnalysis Technical Environment Intercomparison Project (CREATE-IP) |
-| qv56 | Reference Datasets for Climate Model Analysis/Forcing |
-| rr3 | ESGF CMIP5 Australian Data Publication |
-| rt52 | ERA5 Replicated Data: Single and pressure-levels data |
-| tm70 | ACCESS-NRI Working Project |
-| ub7 | Seasonal Prediction ACCESS-S1 hindcast  |
-| uc16 | ERA5 Replicated Datasets on Potential Temperature and Potential Vorticity Levels |
-| ux62 | Seasonal Prediction ACCESS-S2 Hindcast (1981-2018) and Supporting Data Assimilation and Initial Conditions |
-| v45 | Ocean Extremes |
-| xp65 | CESS MED Analysis Environments |
-| zv2 | Australian Gridded Climate Data (AGCD) Collection |
-| zz93 | ERA5-Land Replicated Data |
+| Project | Description with link, * indicated compute resource|
+|------|---------------------------------------------------------------------------------------------------------------------------------|
+| | *ACCESS-NRI projects* |
+| tm70 | <a href="https://my.nci.org.au/mancini/project/tm70" target="_blank">ACCESS-NRI Working Project</a> * |
+| iq82 | <a href="https://my.nci.org.au/mancini/project/iq82" target="_blank">ACCESS-NRI MED Compute</a> * |
+| kj13 | <a href="https://my.nci.org.au/mancini/project/kj13" target="_blank">ACCESS-NRI MED Data Dev</a> |
+| ct11 | <a href="https://my.nci.org.au/mancini/project/ct11" target="_blank">ACCESS-NRI Replicated Datasets</a> |
+| xp65 | <a href="https://my.nci.org.au/mancini/project/xp65" target="_blank">ACCESS-NRI Analysis Environments</a> |
+| | *ACCESS projects* |
+| access | <a href="https://my.nci.org.au/mancini/project/access" target="_blank">ACCESS software sharing</a> |
+| p66  | <a href="https://my.nci.org.au/mancini/project/p66"  target="_blank">ACCESS - AOGCM / suppport development of the ACCESS modelling system</a> * |
+| p73  | <a href="https://my.nci.org.au/mancini/project/p73"  target="_blank">ACCESS Model Output Archive (AOGCM)</a> |
+| | *Data projects* |
+| hh5  | <a href="https://my.nci.org.au/mancini/project/hh5"  target="_blank">Climate-LIEF Data Storage</a> |
+| ub7  | <a href="https://my.nci.org.au/mancini/project/ub7"  target="_blank">Seasonal Prediction ACCESS-S1 Hindcast</a> |
+| ux62 | <a href="https://my.nci.org.au/mancini/project/ux62" target="_blank">Seasonal Prediction ACCESS-S2 Hindcast</a> |
+| cb20 | <a href="https://my.nci.org.au/mancini/project/cb20" target="_blank">ESGF CMIP3 Replication Data</a> |
+| al33 | <a href="https://my.nci.org.au/mancini/project/al33" target="_blank">ESGF CMIP5 Replication Data</a> |
+| rr3  | <a href="https://my.nci.org.au/mancini/project/rr3"  target="_blank">ESGF CMIP5 Australian Data Publication</a> |
+| oi10 | <a href="https://my.nci.org.au/mancini/project/oi10" target="_blank">ESGF CMIP6 Replication Data</a> |
+| fs38 | <a href="https://my.nci.org.au/mancini/project/fs38" target="_blank">ESGF CMIP6 Australian Data Publication</a> |
+| rt52 | <a href="https://my.nci.org.au/mancini/project/rt52" target="_blank">ERA5 Replicated Data: Single and pressure-levels data</a> |
+| uc16 | <a href="https://my.nci.org.au/mancini/project/uc16" target="_blank">ERA5 Replicated Datasets on Potential Temperature & Vorticity Levels</a> |
+| zz93 | <a href="https://my.nci.org.au/mancini/project/zz93" target="_blank">ERA5-Land Replicated Data</a> |
+| zv2  | <a href="https://my.nci.org.au/mancini/project/zv2"  target="_blank">Australian Gridded Climate Data (AGCD) Collection</a> |
+| qv56 | <a href="https://my.nci.org.au/mancini/project/qv56" target="_blank">Reference Datasets for Climate Model Analysis/Forcing</a> |
+| cj50 | <a href="https://my.nci.org.au/mancini/project/cj50" target="_blank">COSIMA Model Output Collection</a> |
+| | *Other projects* |
+| ik11 | <a href="https://my.nci.org.au/mancini/project/ik11" target="_blank">COSIMA shared working space</a> |
+| v45  | <a href="https://my.nci.org.au/mancini/project/v45"  target="_blank">Ocean Extremes</a> * |
+| ga6  | <a href="https://my.nci.org.au/mancini/project/ga6"  target="_blank">Modelling the formation of sedimentary basins and continental margins</a> * |
+| m18  | <a href="https://my.nci.org.au/mancini/project/m18"  target="_blank">Evolution and dynamics of the Australian lithosphere</a> * |
+| q97  | <a href="https://my.nci.org.au/mancini/project/q97"  target="_blank">Earth dynamics and resources over the last billion years</a> * |
+| qu79 | <a href="https://my.nci.org.au/mancini/project/qu79" target="_blank">Collaborative REAnalysis Technical Environment Intercomparison Project (CREATE-IP)</a> |
 
 To join a project or find more projects, please use this [NCI website](https://my.nci.org.au/mancini/project-search).
 
 The first project that you join will become your default login project, e.g. `xp65`. We will refer to it as `$PROJECT` and we show you how to change it below.
 
-## 3) SSH onto gadi@NCI
+## 3) Logging in to Gadi@NCI
 
 If you have never logged onto Gadi before, we recommend to take a look at NCI's [Welcome to Gadi website](https://opus.nci.org.au/display/Help/0.+Welcome+to+Gadi).
 It provides all the important commands and information for logging properly onto Gadi, like the following:
@@ -74,4 +84,40 @@ you will enter your $HOME directory with your default `$PROJECT` and your defaul
 cat $HOME/.config/gadi-login.conf
 ```
 
+The `-Y` option is needed to run graphical tools by enabling the forwarding of trusted X protocol mesgs between X-Server on local system and X programs on Gadi. 
+You need to enable X Windowing system on your local system before running ssh. This can be done by running X-Server like XQuartz (Mac), MobaXterm (MS Windows), startx or similar (Linux).
+
 Again, for more useful information we recommend to check out NCI's [Welcome to Gadi website](https://opus.nci.org.au/display/Help/0.+Welcome+to+Gadi).
+
+## 4) Computing on Gadi
+
+### Gadi Resources
+Coupled climate models like ACCESS-CM involve, among other things, calculation of complex mathematical equations that explain the physics of the atmosphere and oceans. Performed at hundreds of millions of points around the Earth, these calculations require vast computing power to complete them in a reasonable amount of time, thus relying on the power of  high-performance computing (HPC) like Gadi. The [Gadi supercomputer](https://nci.org.au/our-systems/hpc-systems) can handle more than 10 million billion (10 quadrillion) calculations per second and is connected to 100,000 Terabytes of high-performance research data storage.
+
+An overview of [Gadi resources](https://opus.nci.org.au/display/Help/0.+Welcome+to+Gadi#id-0.WelcometoGadi-GadiResources) such as compute, storage and PBS jobs are described below. 
+
+Useful NCI commands to check your available compute resources are:
+
+| Command                |   Purpose                  |
+| ---------------------- | -------------              |
+| `logout` or ++ctrl+"D"++ | To exit a session          |
+| `hostname`             | Displays login node details|
+| `module list`          | Modules currently loaded   |
+| `module avail`         | Available modules          |
+| `nci_account -P [proj]`| Compute allocation for [proj]|
+| `nqstat -P [proj]`     | Jobs running/queued in [proj]|
+| `lquota`               | Storage allocation and usage for all your projects|
+
+#### Compute Hours
+Compute allocations are granted to projects instead of directly to users and, hence, you need to be a member of a project in order to use its compute allocation. To run jobs on Gadi, you need to have sufficient allocated [compute hours](https://opus.nci.org.au/display/Help/0.+Welcome+to+Gadi#id-0.WelcometoGadi-ComputeHours) available, where the [job cost](https://opus.nci.org.au/display/Help/2.+Compute+Grant+and+Job+Debiting) depends on the resources reserved for the job and the amount of walltime it uses. 
+
+#### Storage 
+Each user has a project-independent [`$HOME`](https://opus.nci.org.au/display/Help/0.+Welcome+to+Gadi#id-0.WelcometoGadi-TheHomeFolder$HOME) directory, which has a storage limit of 10 GiB. All data on `/home` is backed up.
+
+Through project membership, the user gets access to the storage space within the
+[project folders](https://opus.nci.org.au/display/Help/0.+Welcome+to+Gadi#id-0.WelcometoGadi-ProjectFolderonLustreFilesystems/scratchand/g/data) `/scratch` and  `/g/data` filesystems for that particular project.
+
+#### PBS Jobs
+To run compute tasks such as an ACCESS-CM suite on Gadi, users need to submit them as *jobs* to *queues*. Within a [job submission](https://opus.nci.org.au/display/Help/0.+Welcome+to+Gadi#id-0.WelcometoGadi-JobSubmission), you can specify the queue, duration and computational resources needed for your job. When a job submission is accepted, it is assigned a jobID (shown in the return message) that can then be used to monitor the job’s [status](https://opus.nci.org.au/display/Help/0.+Welcome+to+Gadi#id-0.WelcometoGadi-QueueStatus). 
+
+On job completion, contents of the job’s standard output/error stream gets copied to a file in the working directory with the respective format: `<jobname>.o<jobid>` and `<jobname>.e<jobid>`. Users should check these two log files before proceeding with post-processing of any output from their corresponding job.

--- a/docs/models/running-a-model/getting_started/access_to_gadi_at_nci.md
+++ b/docs/models/running-a-model/getting_started/access_to_gadi_at_nci.md
@@ -3,7 +3,7 @@ hide:
   - toc
 ---
 
-# <div class="highlight-bg"> Getting Started: Access To Gadi@NCI </div>
+# <div class="highlight-bg"> Getting Started: Computing Access (Gadi@NCI) </div>
 
 Here, we provide you the important information to give you access to the large data that we curate at NCI's storage:
 

--- a/docs/models/running-a-model/running-access-cm.md
+++ b/docs/models/running-a-model/running-access-cm.md
@@ -4,18 +4,16 @@ This section includes a step-by-step instruction set on how to run the **ACCESS-
 It is also built as a future point of reference, where you can come back and find the section containing the information you need.
 
 ## **Getting Started**
-This section outlines some key user requirements and preparations before getting started with running ACCESS-CM suites. To proceed further, you will need to have:
 
-- An institutional email address with an organisation that allows access to NCI (e.g., CSIRO, a university, etc.).
-- Access to NCI compute/storage.
-- A Linux/Mac/Unix computer with an internet connection and a command line terminal (e.g., MacOS with XQuartz and command line tools installed, or Putty Cygwin/MobaXterm/similar X-Windows compatible program on a PC). 
+This section outlines some key user requirements and preparations before getting started with running ACCESS-CM suites.
 
 ### Requirements for running ACCESS-CM suites 
+
+Here, we assume that you already have access to Gadi, the supercomputer hosted by the National Computational Infrastructure (NCI). If needed, you can go back to our guide on how to get [access to Gadi](../running-a-model/getting_started/access_to_gadi_at_nci.md).
 
 #### Basic Setup 
 To run an ACCESS-CM suite, new users will need to:
 
-- [Create an NCI account](https://opus.nci.org.au/display/Help/How+to+create+an+NCI+user+account) through the NCI online self-service portal.
 - [Join the ACCESS group](https://my.nci.org.au/mancini/project/access/join). You can also find instructions on how to [join a particular project](https://opus.nci.org.au/display/Help/How+to+connect+to+a+project) through the NCI self-service portal. 
 - [Connect to accessdev](https://accessdev.nci.org.au/trac/wiki/GettingConnected) to complete your setup once you have your NCI credentials and are a member of the ACCESS group. 
 *Note:* At present, both accessdev and [ARE](https://opus.nci.org.au/display/Help/ARE+User+Guide) run the models on Gadi. However, ARE only supports shorter-running suites (i.e., runs less than 48 hours). Work is currently in progress to fully transition the cylc workflows from accessdev virtual machine to the ARE.
@@ -37,6 +35,7 @@ At this stage, you should be able to connect to accessdev and Gadi.
 [accessdev](https://accessdev.nci.org.au) is a frontend system where you prepare ACCESS jobs and then submit them to [Gadi](https://nci.org.au/our-systems/hpc-systems) (the supercomputer at NCI where ACCESS is run).  
 
 #### Logging in to Gadi and accessdev
+
 To run an ACCESS-CM2 suite (i.e., job), you need to first [login to Gadi](https://opus.nci.org.au/display/Help/0.+Welcome+to+Gadi#id-0.WelcometoGadi-LoggingIn&LoginNodes) with your `username` through a login node. 
 
 `ssh -Y username@gadi.nci.org.au`
@@ -45,41 +44,7 @@ Similarly, to login to accessdev:
 
 `ssh -Y $USER@accessdev.nci.org.au`
 
-The `–Y` switch is used to allow trusted X11 forwarding. Aliases and shortcuts can be created to simplify these commands by [configuring SSH](https://accessdev.nci.org.au/trac/wiki/Guides/SSH).
-
-
-#### Useful NCI commands 
-
-| Command                |   Purpose                  |
-| ---------------------- | -------------              |
-| `logout` or ++ctrl+"D"++ | To exit a session          |
-| `hostname`             | Displays login node details|
-| `module list`          | Modules currently loaded   |
-| `module avail`         | Available modules          |
-| `nci_account -P [proj]`| Compute allocation for [proj]|
-| `nqstat -P [proj]`     | Jobs running/queued in [proj]|
-| `lquota`               | Storage allocation and usage for all your projects|
-
---------------------------------------------
-
-### Gadi Resources
-Coupled climate models like ACCESS-CM involve, among other things, calculation of complex mathematical equations that explain the physics of the atmosphere and oceans. Performed at hundreds of millions of points around the Earth, these calculations require vast computing power to complete them in a reasonable amount of time, thus relying on the power of  high-performance computing (HPC) like Gadi. The [Gadi supercomputer](https://nci.org.au/our-systems/hpc-systems) can handle more than 10 million billion (10 quadrillion) calculations per second and is connected to 100,000 Terabytes of high-performance research data storage.
-
-An overview of [Gadi resources](https://opus.nci.org.au/display/Help/0.+Welcome+to+Gadi#id-0.WelcometoGadi-GadiResources) such as compute, storage and PBS jobs are described below. 
-
-#### Compute Hours
-Compute allocations are granted to projects instead of directly to users and, hence, you need to be a member of a project in order to use its compute allocation. To run jobs on Gadi, you need to have sufficient allocated [compute hours](https://opus.nci.org.au/display/Help/0.+Welcome+to+Gadi#id-0.WelcometoGadi-ComputeHours) available, where the [job cost](https://opus.nci.org.au/display/Help/2.+Compute+Grant+and+Job+Debiting) depends on the resources reserved for the job and the amount of walltime it uses. 
-
-#### Storage 
-Each user has a project-independent [`$HOME`](https://opus.nci.org.au/display/Help/0.+Welcome+to+Gadi#id-0.WelcometoGadi-TheHomeFolder$HOME) directory, which has a storage limit of 10 GiB. All data on `/home` is backed up.
-
-Through project membership, the user gets access to the storage space within the
-[project folders](https://opus.nci.org.au/display/Help/0.+Welcome+to+Gadi#id-0.WelcometoGadi-ProjectFolderonLustreFilesystems/scratchand/g/data) `/scratch` and  `/g/data` filesystems for that particular project.
-
-#### PBS Jobs
-To run compute tasks such as an ACCESS-CM suite on Gadi, users need to submit them as *jobs* to *queues*. Within a [job submission](https://opus.nci.org.au/display/Help/0.+Welcome+to+Gadi#id-0.WelcometoGadi-JobSubmission), you can specify the queue, duration and computational resources needed for your job. When a job submission is accepted, it is assigned a jobID (shown in the return message) that can then be used to monitor the job’s [status](https://opus.nci.org.au/display/Help/0.+Welcome+to+Gadi#id-0.WelcometoGadi-QueueStatus). 
-
-On job completion, contents of the job’s standard output/error stream gets copied to a file in the working directory with the respective format: `<jobname>.o<jobid>` and `<jobname>.e<jobid>`. Users should check these two log files before proceeding with post-processing of any output from their corresponding job.
+Aliases and shortcuts can be created to simplify these commands by [configuring SSH](https://accessdev.nci.org.au/trac/wiki/Guides/SSH).
 
 --------------------------------------------
 # Copy, Edit, and Run an ACCESS-CM2 suite

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -126,7 +126,7 @@ nav:
     # - Getting Started: 
     #   - models/running-a-model/getting_started/index.md
     #   - Access to Gadi@NCI: models/running-a-model/getting_started/access_to_gadi_at_nci.md
-    - Access to Gadi@NCI: models/running-a-model/getting_started/access_to_gadi_at_nci.md
+    - Computing Access (Gadi@NCI): models/running-a-model/getting_started/access_to_gadi_at_nci.md
     - Run ACCESS-ESM: models/running-a-model/running-access-esm.md
     - Run ACCESS-CM: models/running-a-model/running-access-cm.md
     - Run ACCESS-AM: models/running-a-model/running-access-am.md
@@ -136,7 +136,7 @@ nav:
     - model_evaluation/index.md
     - Getting Started: 
       - model_evaluation/model_evaluation_getting_started/index.md
-      - Access to Gadi@NCI: model_evaluation/model_evaluation_getting_started/access_to_gadi_at_nci.md
+      - Computing Access (Gadi@NCI): model_evaluation/model_evaluation_getting_started/access_to_gadi_at_nci.md
       - Model Evaluation on Gadi: model_evaluation/model_evaluation_getting_started/model_evaluation_getting_started.md
     - Observational Data Catalog: model_evaluation/model_evaluation_observational_catalogs.md
     - Model Data Catalog:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,7 +44,7 @@ theme:
     - search.share
     - toc.follow
 
-    # - navigation.expand
+    - navigation.expand # reintroduced
     # - navigation.path
     # - toc.integrate
     # - navigation.sections
@@ -138,17 +138,21 @@ nav:
       - model_evaluation/model_evaluation_getting_started/index.md
       - Computing Access (Gadi@NCI): model_evaluation/model_evaluation_getting_started/access_to_gadi_at_nci.md
       - Model Evaluation on Gadi: model_evaluation/model_evaluation_getting_started/model_evaluation_getting_started.md
-    - Observational Data Catalog: model_evaluation/model_evaluation_observational_catalogs.md
-    - Model Data Catalog:
-      - model_evaluation/model_evaluation_model_catalogs/index.md
-      - Search Model Catalog: model_evaluation/model_evaluation_model_catalogs/model_evaluation_search_models.md
-      - Add your Model to the Catalog: model_evaluation/model_evaluation_model_catalogs/model_evaluation_add_models.md
-    - Data Format Processing: model_evaluation/model_evaluation_data_processing.md
-    - Model Evaluation on Gadi: 
+    - Data Catalogs:
+      - Observational Data: model_evaluation/model_evaluation_observational_catalogs.md
+      - Model Data:
+        - model_evaluation/model_evaluation_model_catalogs/index.md
+        - Search Model Catalog: model_evaluation/model_evaluation_model_catalogs/model_evaluation_search_models.md
+        - Add your Model to the Catalog: model_evaluation/model_evaluation_model_catalogs/model_evaluation_add_models.md
+        - Model Format Processing: model_evaluation/model_evaluation_data_processing.md
+    - Evaluation Tools: 
       - model_evaluation/model_evaluation_on_gadi/index.md
-      - ilamb: model_evaluation/model_evaluation_on_gadi/model_evaluation_on_gadi_ilamb.md
-      - esmvalltool: model_evaluation/model_evaluation_on_gadi/model_evaluation_on_gadi_esmvaltool.md
-    - Evaluation Recipe Gallery: model_evaluation/model_evaluation_recipe_gallery.md
+      - Frameworks on Gadi:
+         - ILAMB: model_evaluation/model_evaluation_on_gadi/model_evaluation_on_gadi_ilamb.md
+         - ESMValTool: model_evaluation/model_evaluation_on_gadi/model_evaluation_on_gadi_esmvaltool.md
+         - Pangeo & COSIMA: model_evaluation/model_evaluation_on_gadi/model_evaluation_on_gadi_pangeo_cosima.md
+      - Live-Diagnostics on Gadi: model_evaluation/model_evaluation_live_diagnostics.md
+      - Evaluation Recipe Gallery: model_evaluation/model_evaluation_recipe_gallery.md
 
   - Community Resources:
     - community_resources/index.md


### PR DESCRIPTION
In response to #342 "Final decision: Need to lock in high-level navigation of Hive tabs"

@rbeucher adjusted as discussed in our meeting today. I am not sure yet, if Observational + Model Data Catalogs should be under one big section or each in their own.

<img width="267" alt="med_navi" src="https://github.com/ACCESS-Hive/access-hive.github.io/assets/22073890/cbd089f8-0793-4fc0-98f9-3eae38e25518">
