### PR TITLE
MED Intro clarification

### DIFF
--- a/docs/model_evaluation/index.md
+++ b/docs/model_evaluation/index.md
@@ -4,6 +4,14 @@
 
 ACCESS-NRI's Model Evaluation and Diagnostics (MED) work is a critical facet of climate modeling, encompassing various tasks designed to ensure the model's reliability and accuracy.
 
+## What is MED about?
+
+**Evaluation** involves scrutinizing the model through Model/Observation confrontations, checking its performance against real-world observations. It also includes experiment comparisons, testing the model under different scenarios, and inter-model comparisons like the Coupled Model Intercomparison Project (CMIP), assessing how the ACCESS-NRI model fares when compared with other climate models.
+
+**Diagnostics** involves constant monitoring of model runs to detect any anomalies or inconsistencies and a thorough analysis of outputs to verify the model's accuracy over time.
+
+## Getting Started with MED
+
 If you are new to model evaluation and diagnostics, we recommend you read our [Getting Started with MED page](./model_evaluation_getting_started/index.md):
 <div class="card-container">
     <a href="../get_started" class="squared-card default-text-color">
@@ -14,9 +22,9 @@ If you are new to model evaluation and diagnostics, we recommend you read our [G
     </a>
     <a href="model_evaluation_getting_started/model_evaluation_getting_started" class="squared-card default-text-color">
         <div class="squared-card-image-container">
-            <img src="../assets/model_evaluation/model_evaluation_conda.png" alt="MED Conda Environment"></img>
+            <img src="../assets/model_evaluation/model_evaluation_conda.png" alt="Model Evaluation on Gadi"></img>
         </div>
-        <div class="squared-card-text-container bold">MED Conda Environment</div>
+        <div class="squared-card-text-container bold">Model Evaluation on Gadi</div>
     </a>
     <a href="model_evaluation_getting_started/model_variables" class="squared-card default-text-color">
         <div class="squared-card-image-container">
@@ -88,7 +96,7 @@ We are currently setting up a range of tools that will help you to better evalua
 
 While we are working on these, we have collected a number of links to existing tools in our [community tab](../community_resources/index.md) (note that we are not currating them).  
 
-{% include "call_contribute.md" %}
+<!-- {% include "call_contribute.md" %} -->
 
 <!-- 
 
@@ -124,9 +132,3 @@ TBD: Tools to check if data is CMOR-compliant (raise issue)
 TBD: Discuss with Dougie: How can we identify what is CMORized and what is not?
 
 -->
-
-## What is MED about?
-
-**Evaluation** involves scrutinizing the model through Model/Observation confrontations, checking its performance against real-world observations. It also includes experiment comparisons, testing the model under different scenarios, and inter-model comparisons like the Coupled Model Intercomparison Project (CMIP), assessing how the ACCESS-NRI model fares when compared with other climate models.
-
-**Diagnostics** involves constant monitoring of model runs to detect any anomalies or inconsistencies and a thorough analysis of outputs to verify the model's accuracy over time.

--- a/docs/model_evaluation/index.md
+++ b/docs/model_evaluation/index.md
@@ -2,7 +2,7 @@
 
 <!-- Model evaluation is about measuring how fit for purpose a particular model is.  -->
 
-ACCESS-NRI's Model Evaluation and Diagnostics (MED) work is a critical facet of climate modeling that includes the comparison of different models and their confrontation with real-world data to test a model's reliability and accuracy in order to draw scientific conclusions.
+Model evaluation in climate science is the process of assessing the performance and reliability of computational models that simulate Earth's climate system. It involves comparing model predictions to observed data to determine the model's accuracy and usefulness. This process helps understand how well a model represents real-world climate processes and predict future climate trends. Through rigorous evaluation, scientists can identify model strengths, weaknesses, and uncertainties, refining models to enhance their predictive capabilities.
 
 ## Getting Started with MED
 

--- a/docs/model_evaluation/index.md
+++ b/docs/model_evaluation/index.md
@@ -2,17 +2,12 @@
 
 <!-- Model evaluation is about measuring how fit for purpose a particular model is.  -->
 
-ACCESS-NRI's Model Evaluation and Diagnostics (MED) work is a critical facet of climate modeling, encompassing various tasks designed to ensure the model's reliability and accuracy.
-
-## What is MED about?
-
-**Evaluation** involves scrutinizing the model through Model/Observation confrontations, checking its performance against real-world observations. It also includes experiment comparisons, testing the model under different scenarios, and inter-model comparisons like the Coupled Model Intercomparison Project (CMIP), assessing how the ACCESS-NRI model fares when compared with other climate models.
-
-**Diagnostics** involves constant monitoring of model runs to detect any anomalies or inconsistencies and a thorough analysis of outputs to verify the model's accuracy over time.
+ACCESS-NRI's Model Evaluation and Diagnostics (MED) work is a critical facet of climate modeling that includes the comparison of different models and their confrontation with real-world data to test a model's reliability and accuracy in order to draw scientific conclusions.
 
 ## Getting Started with MED
 
-If you are new to model evaluation and diagnostics, we recommend you read our [Getting Started with MED page](./model_evaluation_getting_started/index.md):
+If you are new to MED and are wondering [*"What is Model Evaluation and Diagnostics about?"*](./model_evaluation_getting_started/index.md), we recommend you read our [Getting Started with MED page](./model_evaluation_getting_started/index.md):
+
 <div class="card-container">
     <a href="../get_started" class="squared-card default-text-color">
         <div class="squared-card-image-container">
@@ -33,8 +28,6 @@ If you are new to model evaluation and diagnostics, we recommend you read our [G
         <div class="squared-card-text-container bold">Model Variables</div>
     </a>
 </div>
-
-Here, we provide catalogs and pointers to [observational data](./model_evaluation_observational_catalogs.md) as well as [model data](./model_evaluation_model_catalogs/index.md) that can be used for evaluation. We also provide a number of [frameworks for model evaluation](./model_evaluation_on_gadi/index.md). We are also working on implementing more frameworks and recipes as well as formatting tools for a better model evaluation and diagnostics.
 
 ## ACCESS-MED data and tools hosted on Gadi
 

--- a/docs/model_evaluation/model_evaluation_getting_started/index.md
+++ b/docs/model_evaluation/model_evaluation_getting_started/index.md
@@ -21,9 +21,9 @@ Here, we provide you the important information to give you access to the large d
     </a>
     <a href="model_evaluation_getting_started" class="squared-card default-text-color">
         <div class="squared-card-image-container">
-            <img src="../../assets/model_evaluation/model_evaluation_conda.png" alt="MED Conda Environment"></img>
+            <img src="../../assets/model_evaluation/model_evaluation_conda.png" alt="Model Evaluation on Gadi"></img>
         </div>
-        <div class="squared-card-text-container bold">MED Conda Environment</div>
+        <div class="squared-card-text-container bold">Model Evaluation on Gadi</div>
     </a>
     <a href="model_variables" class="squared-card default-text-color">
         <div class="squared-card-image-container">

--- a/docs/model_evaluation/model_evaluation_getting_started/model_evaluation_getting_started.md
+++ b/docs/model_evaluation/model_evaluation_getting_started/model_evaluation_getting_started.md
@@ -1,4 +1,4 @@
-# Model Evaluation Environment at NIC's Gadi
+# Model Evaluation on Gadi
 
 At this stage of *Getting Started*, we assume that you already have access to NCI's Gadi. If this is not the case, please go to our instructions on how to get [access to NCI's Gadi](../../get_started/index.md).
 


### PR DESCRIPTION
This PR is addressing issue #501 (suggestion to move "What is MED about?" to beginning of MED intro).

I would suggest to only answer the question "What is MED about?" into the *Getting Started with MED* page to not have it take up the upper part of the page (and remove it from the top of the MED intro page). Do you agree?

I am also wondering, if we should add an informative overview in the "getting started with MED" section? Or should this maybe even go at the beginning of the main MED page?

<img width="516" alt="med_explanation" src="https://github.com/ACCESS-Hive/access-hive.github.io/assets/22073890/94aecd03-bb75-4f70-8888-d24f5c13729e">
