### PR TITLE
Get rid of hardcoded repo/organization names in the workflows

### DIFF
--- a/.github/workflows/deploy_to_github_pages.yml
+++ b/.github/workflows/deploy_to_github_pages.yml
@@ -1,11 +1,11 @@
 name: Deploy to GitHub Pages
 on:
   push: #Action fires anytime there is a push to the following branches
-    branches: 
+    branches:
       - main
       - development
   pull_request: #Action also fires anytime a PR is (re)opened, closed or synchronized
-    types: 
+    types:
       - opened
       - reopened
       - synchronize
@@ -35,12 +35,12 @@ jobs:
 
             🛫 Deployment still ongoing.<br>
             Preview URL will be available at the end of the deployment.
-            
-            For more information, please check the [Actions](https://github.com/ACCESS-Hive/access-hive.github.io/actions) tab.
+
+            For more information, please check the [Actions](https://github.com/${{ github.repository }}/actions) tab.
 
             ${{ env.DATE }}
             "
-      
+
       - name: Setup development preview
         # If the PR is from the development branch and is new (or has been reopened),
         # setup the message that will get updated with the URL after deployment
@@ -57,7 +57,7 @@ jobs:
             🛫 Deployment still ongoing.<br>
             Preview URL will be available at the end of the deployment.
 
-            For more information, please check the [Actions](https://github.com/ACCESS-Hive/access-hive.github.io/actions) tab.
+            For more information, please check the [Actions](https://github.com/${{github.repository}}/actions) tab.
 
             ${{ env.DATE }}
             "
@@ -71,14 +71,14 @@ jobs:
           pr_number: ${{ github.event.number }}
           message: "\
             PR Preview
-      
+
             :---:
-      
+
             🛬 Link removed because the pull request was closed.
-      
+
             ${{ env.DATE }}
             "
-      
+
       # If the PR is closed, remove the development URL
       - name: Remove development URL
         if: ${{github.event.action == 'closed' && github.event.pull_request.head.ref == 'development' }}
@@ -88,14 +88,14 @@ jobs:
           pr_number: ${{ github.event.number }}
           message: "\
             Development website preview
-      
+
             :---:
-      
+
             🛬 Preview removed because the pull request was closed.
-      
+
             ${{ env.DATE }}
             "
-  
+
   build:
     # Cancel any previous build/deploy jobs that are still running (no need to build/deploy multiple times)
     concurrency:
@@ -107,7 +107,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      
+
       - name: Python setup
         uses: actions/setup-python@v5
         with:
@@ -139,7 +139,7 @@ jobs:
               eval "$command"
             done
           }
-          
+
           git fetch --all
           echo "Build main website"
           retry "git checkout main" 5 1 "Failed to checkout 'main'."
@@ -148,8 +148,8 @@ jobs:
           retry 'git checkout development' 5 1 "Failed to checkout 'development' branch."
           retry 'mkdocs build -f mkdocs.yml -d ../website/development-website' 5 1 "Failed to build development website."
           echo "Build PR websites"
-          command="pr_list=\$(curl -s https://api.github.com/repos/ACCESS-Hive/access-hive.github.io/pulls?state=opened \
-          | jq '.[] | select(.head.label!=\"ACCESS-Hive:development\" and .head.label!=\"ACCESS-Hive:main\")')"
+          command="pr_list=\$(curl -s https://api.github.com/repos/${{github.repository}}/pulls?state=opened \
+          | jq '.[] | select(.head.label!=\"${{ github.repository_owner }}:development\" and .head.label!=\"${{ github.repository_owner }}:main\")')"
           retry "$command" 5 1 "Failed to fetch opened PRs."
           pr_nums=($(jq '.number' <<< $pr_list))
           if [[ -n $pr_nums ]]; then
@@ -165,12 +165,12 @@ jobs:
           fi
           echo "Give the right file permissions"
           chmod -c -R +rX ../website
-      
+
       - name: Create artifact for deployment to GitHub Pages
         uses: actions/upload-pages-artifact@v2
         with:
-          path: ../website      
-      
+          path: ../website
+
   deploy:
     needs: build
     runs-on: ubuntu-latest
@@ -181,21 +181,21 @@ jobs:
     outputs:
       success: ${{ steps.success.outputs.success }}
     permissions:
-      pages: write      # to deploy to Pages
-      id-token: write   # to verify the deployment originates from an appropriate source
+      pages: write # to deploy to Pages
+      id-token: write # to verify the deployment originates from an appropriate source
 
     steps:
       - name: Deploy to GitHub Pages
         uses: actions/deploy-pages@v2
-      
+
       - name: Output success status
         id: success
         run: |
           echo "success=1" >> "$GITHUB_OUTPUT"
-        
+
   # Set pr-preview URL
   pr-preview:
-    needs: [build,deploy]
+    needs: [build, deploy]
     # If there are open PRs (whose head branch is neither `development` nor `main`), run this job
     if: ${{ needs.build.outputs.pr_nums }}
     runs-on: ubuntu-latest
@@ -215,17 +215,17 @@ jobs:
           pr_number: ${{ matrix.pr_nums }}
           message: "\
             PR Preview
-              
+
             :---:
 
             🚀 Deployed preview to
             https://access-hive.org.au/pr-preview/pr-${{ matrix.pr_nums }}
-            
+
             ${{ env.DATE }}
             "
   # Add development URL
   development-preview:
-    needs: [build,deploy]
+    needs: [build, deploy]
     # If there are open PRs (whose head branch is neither `development` nor `main`), run this job
     if: ${{ github.event.pull_request.head.ref == 'development' }}
     runs-on: ubuntu-latest
@@ -241,15 +241,15 @@ jobs:
           pr_number: ${{ github.event.number }}
           message: "\
             Development website preview
-              
+
             :---:
 
             🚀 Development website deployed to
             https://access-hive.org.au/development-website
-            
+
             ${{ env.DATE }}
             "
-  
+
   # Change preview message if deployment fails
   failed-preview:
     needs: deploy
@@ -268,15 +268,15 @@ jobs:
           pr_number: ${{ github.event.number }}
           message: "\
             Development website preview
-              
+
             :---:
 
             ⚠️ There was an error in the deployment of the development website.
-            For more information, please check the [Actions](https://github.com/ACCESS-Hive/access-hive.github.io/actions) tab.
-            
+            For more information, please check the [Actions](https://github.com/${{github.repository}}/actions) tab.
+
             ${{ env.DATE }}
             "
-      
+
       - name: Change pr-preview message
         if: ${{ github.event.pull_request.head.ref != 'development' }}
         uses: thollander/actions-comment-pull-request@v2.4.3
@@ -285,11 +285,11 @@ jobs:
           pr_number: ${{ github.event.number }}
           message: "\
             PR preview
-              
+
             :---:
 
             ⚠️ There was an error in the pr-preview deployment.
-            For more information, please check the [Actions](https://github.com/ACCESS-Hive/access-hive.github.io/actions) tab.
-            
+            For more information, please check the [Actions](https://github.com/${{github.repository}}/actions) tab.
+
             ${{ env.DATE }}
             "


### PR DESCRIPTION
Due to the upcoming move of the repo from the ACCESS-Hive organization to the ACCESS-NRI organization on GitHub, and possible renaming of the repo itself, I got rid of a few harcoded name/organization instances, so the publihing workflow should now work for any name/organization.
