### PR TITLE
Rework build/deployment workflow

### DIFF
--- a/.github/workflows/delete_pr_preview_comment.yml
+++ b/.github/workflows/delete_pr_preview_comment.yml
@@ -1,9 +1,6 @@
 name: Delete PR preview comment
 on:
-  pull_request:
-    types:
-      - closed
-
+  workflow_call
 jobs:
   # Delete PR preview comment
   delete-pr-preview-comment:

--- a/.github/workflows/deploy_to_github_pages.yml
+++ b/.github/workflows/deploy_to_github_pages.yml
@@ -15,33 +15,31 @@ env:
   DOC_DIR: '.'
   BUILD_DIR: ${{ github.workspace }}/website-build
   WEBSITE_DIR: ${{ github.workspace }}/full-website
-  ROOT_DOMAIN: https://docs.access-hive.org.au/
   PR_PREVIEWS_DIR: pr-previews
 concurrency:
   group: documentation-build-deploy
   cancel-in-progress: true
 
 jobs:
-  # Set the root url to be used at build time to set the SITE_URL env variable
+  # Get the root url to be used at build time to set the SITE_URL env variable
   # used in the mkdocs.yml file to construct the website map for links
-  set-root-url:
+  get-root-url:
     name: Set root URL
     runs-on: ubuntu-latest
     outputs:
-      root_url: ${{ steps.set-root-url.outputs.root_url }}
+      root_url: ${{ steps.get-root-url.outputs.root_url }}
+    env:
+      GH_TOKEN: ${{ github.token }} # Required for gh usage
     steps:
-      - name: Set root url
-        id: set-root-url
+      - name: Get root url
+        id: get-root-url
         run: |
-          root_domain=$(sed 's:/*$::' <<< '${{ env.ROOT_DOMAIN }}') # Remove trailing slash if present
-          if [[ "$root_domain" == https://access-nri.github.io ]]; then
-            # If the domain is the default GitHub pages one (not a custom one), the website will be deployed 
-            # as a GitHub Pages Project Site with the URL in the format http://<username>.github.io/<repository>/
-            root_url=${root_domain}/${{ github.event.repository.name }}/
-          else
-            root_url=${root_domain}/
+          root_url=$(gh api repos/${{ github.repository }}/pages --jq '.html_url')
+          if [[ $? != 0 ]]; then
+            echo "::error::The repository '${{ github.repository }}' does not seem to gave a GitHub Pages deployment."
+            exit 1
           fi
-          echo "Root url set to ${root_url}"
+          echo "Root url set to '${root_url}'"
           echo "root_url=${root_url}" >> $GITHUB_OUTPUT
   
   # Get the date to be used in the PR preview comments
@@ -88,7 +86,7 @@ jobs:
   build-main:
     name: Build main website
     runs-on: ubuntu-latest
-    needs: set-root-url
+    needs: get-root-url
     env:
       GH_TOKEN: ${{ github.token }} # Required for gh usage
     steps:
@@ -123,7 +121,7 @@ jobs:
         working-directory: ${{ env.DOC_DIR }}
         env:
           GH_TOKEN: ${{ github.token }} # Required for gh usage
-          ROOT_URL: ${{ needs.set-root-url.outputs.root_url }}
+          ROOT_URL: ${{ needs.get-root-url.outputs.root_url }}
         id: build
         if: ${{ ! env.SKIP_STEP }}
         run: |
@@ -144,7 +142,7 @@ jobs:
   build-development:
     name: Build development website
     runs-on: ubuntu-latest
-    needs: set-root-url
+    needs: get-root-url
     env:
       GH_TOKEN: ${{ github.token }} # Required for gh usage
     steps:
@@ -179,7 +177,7 @@ jobs:
         working-directory: ${{ env.DOC_DIR }}
         env:
           GH_TOKEN: ${{ github.token }} # Required for gh usage
-          ROOT_URL: ${{ needs.set-root-url.outputs.root_url }}
+          ROOT_URL: ${{ needs.get-root-url.outputs.root_url }}
         id: build
         if: ${{ ! env.SKIP_STEP }}
         run: |
@@ -201,12 +199,12 @@ jobs:
   get-prs-info:
     name: Get PRs info
     runs-on: ubuntu-latest
-    needs: set-root-url
+    needs: get-root-url
     outputs:
       open_prs_info: ${{ steps.get-prs-info.outputs.open_prs_info }}
     env:
       GH_TOKEN: ${{ github.token }} # Required for gh usage
-      ROOT_URL: ${{ needs.set-root-url.outputs.root_url }}
+      ROOT_URL: ${{ needs.get-root-url.outputs.root_url }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -269,7 +267,7 @@ jobs:
   build-pr:
     name: Build PR ${{matrix.pr_number}}
     runs-on: ubuntu-latest
-    needs: [set-root-url, get-prs-info]
+    needs: [get-root-url, get-prs-info]
     # Run this job only if there are open PRs
     if: ${{ needs.get-prs-info.outputs.open_prs_info != '' }}
     env:
@@ -298,7 +296,7 @@ jobs:
         working-directory: ${{ env.DOC_DIR }}
         env:
           GH_TOKEN: ${{ github.token }} # Required for gh usage
-          ROOT_URL: ${{ needs.set-root-url.outputs.root_url }}
+          ROOT_URL: ${{ needs.get-root-url.outputs.root_url }}
         id: build
         run: |
           dir=$(sed 's|^${{ env.ROOT_URL }}||' <<< ${{ matrix.pr_preview_url }})
@@ -317,7 +315,7 @@ jobs:
   create-pr-previews-page:
     name: Create PR previews list page
     runs-on: ubuntu-latest
-    needs: [set-root-url, get-prs-info]
+    needs: [get-root-url, get-prs-info]
     env:
       GH_TOKEN: ${{ github.token }} # Required for gh usage
       FILE_NAME: index.html

--- a/.github/workflows/deploy_to_github_pages.yml
+++ b/.github/workflows/deploy_to_github_pages.yml
@@ -1,15 +1,6 @@
 name: Deploy to GitHub Pages
 on:
-  push: #Action fires anytime there is a push to the following branches
-    branches:
-      - main
-      - development
-  pull_request: #Action also fires anytime a PR is (re)opened, closed or synchronized
-    types:
-      - opened
-      - reopened
-      - synchronize
-  workflow_dispatch: #Action can also be triggered manually
+  workflow_call # This workflow can be called by other workflows
 env:
   TZ: Australia/Canberra
   DOC_DIR: '.'

--- a/.github/workflows/deploy_to_github_pages.yml
+++ b/.github/workflows/deploy_to_github_pages.yml
@@ -219,18 +219,26 @@ jobs:
           open_prs=$(
             gh pr list \
             --state open \
-            --json number,title,headRepositoryOwner,headRefOid \
+            --json number,title,headRepositoryOwner,headRefOid,body \
             --jq 'sort_by(.number) | .[] | select( .headRefName!="main" and .headRepositoryOwner.login=="ACCESS-NRI")' \
           )
           
           # If open PRs are found, filter them and output the desired json object
           if [[ -n "$open_prs" ]]; then
-            # Keep only PRs with a mkdocs.yml file in their head commit
-            prs_with_mkdocs=$(
-              while read pr; do
+            # Keep only PRs:
+            # - with a mkdocs.yml file in their head commit
+            # - whose body doesn't start with a "!no-preview" (case insensitive) line
+            regex='^!no-preview\b'
+            filtered_prs=$(
+              while IFS= read -r pr; do
                 sha=$(jq -r '.headRefOid' <<< $pr)
-                if gh api repos/${{ github.repository }}/git/trees/${sha}?recursive=1 | \
-                jq '.tree[].path' | grep 'mkdocs.ya\?ml' > /dev/null; then 
+                body=$(jq -r '.body' <<< $pr)
+                if (
+                  gh api repos/${{ github.repository }}/git/trees/${sha}?recursive=1 | \
+                  jq '.tree[].path' | grep 'mkdocs.ya\?ml' > /dev/null
+                ) && (
+                  ! grep -qi "$regex" <<< "$body"
+                ); then 
                   echo $pr
                 fi
               done <<< "$open_prs"
@@ -247,7 +255,7 @@ jobs:
               pr_title: .title, 
               pr_head_sha: .headRefOid, 
               pr_preview_url: ("${{ env.ROOT_URL }}${{ env.PR_PREVIEWS_DIR }}/" + (.number | tostring))
-              }]' <<< "$prs_with_mkdocs"
+              }]' <<< "$filtered_prs"
             )
             
             echo "Found the following open PRs:"

--- a/.github/workflows/documentation_ci.yml
+++ b/.github/workflows/documentation_ci.yml
@@ -1,0 +1,68 @@
+name: Documentation CI
+description: |
+  This is a master workflow to trigger the documentation build/deploy workflow based on the following
+  conditions:
+  - If the workflow is triggered by a push, it triggers the documentation 
+    build/deploy workflow
+  - If the workflow is triggered by a PR (opened, reopened, or synchronized):
+    - A message to the PR gets added but NO documentation build/deploy workflow
+      get triggered if:
+        - The PR comes from a fork
+        - The PR body starts with the `!no-preview` keyword line
+        - The `documentation` folder doesn't contain neither a `mkdocs.yaml` config file nor
+          a `stub` folder with a single `.md` or `.html` file in it.
+    - In all other cases the documentation build/deploy workflow gets triggered
+  - If the workflow is triggered by a closed PR:
+    Deletes the PR message from the PR, if it exists
+on:
+  push: #Action fires anytime there is a push to the following branches
+    branches:
+      - main
+      - development
+  pull_request: #Action also fires anytime a PR is (re)opened, closed or synchronized
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - closed
+
+# !!! IMPORTANT !!!
+# TODO: Change workflow versions to @main after testing
+# !!! IMPORTANT !!!
+jobs:
+  # Check if the documentation build/deploy workflow needs to be run
+  check-documetation-deployment:
+    name: Check if documentation deployment is needed
+    if: github.event_name == 'pull_request' && github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    outputs:
+      needs_deployment: ${{ steps.set-output.outputs.needs_deployment }}
+    steps:
+      - name: Check if PR is from a fork
+        id: check-fork
+        uses: access-nri/access-hive.org.au/.github/actions/check-fork@davide/940-exclude_PRs_from_preview
+
+      - name: Check if PR body starts with !no-preview
+        id: check-no-preview
+        uses: access-nri/access-hive.org.au/.github/actions/check-no-preview@davide/940-exclude_PRs_from_preview
+
+      - name: Check if documentation folder contains mkdocs.yaml or stub folder
+        id: check-doc-folder
+        uses: access-nri/access-hive.org.au/.github/actions/check-doc-folder@davide/940-exclude_PRs_from_preview
+
+      - name: Set output for following jobs
+        id: set-output
+        run: echo "needs_deployment=$(if [[ '${{ steps.check-fork.outputs.is_fork }}' == 'true' || '${{ steps.check-no-preview.outputs.has_no_preview }}' == 'true' || '${{ steps.check-doc-folder.outputs.has_valid_docs }}' == 'false' ]]; then echo 'false'; else echo 'true'; fi)" >> $GITHUB_ENV
+
+
+  # Trigger the documentation build/deploy workflow
+  build-and-deploy:
+    name: Build and deploy documentation
+    if: github.event_name == 'push'
+    uses: access-nri/access-hive.org.au/.github/workflows/deploy_to_github_pages.yml@davide/940-exclude_PRs_from_preview
+
+  # Delete the PR preview comment if the PR was closed
+  delete-pr-preview-comment:
+    name: Set root URL
+    if: github.event_name == 'pull_request' && github.event.action == 'closed'
+    uses: access-nri/access-hive.org.au/.github/workflows/delete_pr_preview_comment.yml@davide/940-exclude_PRs_from_preview


### PR DESCRIPTION
!NO-PREVIEW

## Changes
- [x] Added keyword (`!no-preview` - case insensitive) to prevent PRs from being included in the PR previews
- [x] `root_url` gets inferred from the `gh api` REST endpoint for pages: `gh api repos/:owner/:repo/pages` and the root_url taken from the `html_url` field
- [ ] Implemented wrapper script to call the Deploy to GitHub Pages script when needed. This manages:
  - PRs from forks (Deploy to GitHub Pages script doesn't get called)
  - PRs with `!no-preview` keyword (Deploy to GitHub Pages script doesn't get called)
  - Other PRs (Deploy to GitHub Pages script gets called)
- [ ] Address #953 
