### PR TITLE
Create a Prerelease: Remove reference to projections

### DIFF
--- a/docs/models/run-a-model/create-a-prerelease.md
+++ b/docs/models/run-a-model/create-a-prerelease.md
@@ -90,18 +90,14 @@ In this example, we will change ACCESS-OM2's [MOM5 component] by replacing it wi
 To achieve this, the following steps will be carried out:
 
 1. Retrieve the _Git_ hash (_LONG\_HASH_) for the `development` head commit.
-   
+
     !!! warning
         Currently, only _Git_ tags and commit hashes are supported for specifying component versions.<br>
         To use a _Git_ branch, its corresponding commit hash should be retrieved and used instead.
 
 2. Update the [version of the `mom5` package](https://github.com/ACCESS-NRI/ACCESS-OM2/blob/d907f3314a9956875baaaaf2b4d7b6be6fa81926/spack.yaml#L15) in the `spack.yaml` file with the new version (i.e., `@git.LONG_HASH`).
-3. Update the [associated module projection](https://github.com/ACCESS-NRI/ACCESS-OM2/blob/d907f3314a9956875baaaaf2b4d7b6be6fa81926/spack.yaml#L53) to `{name}/development-{hash:7}`.<br>
 
-    !!! tip
-        The `{hash:7}` part is used so the module doesn't conflict with other versions.
-
-4. It is also recommended to update the [overall ACCESS-OM2 version](https://github.com/ACCESS-NRI/ACCESS-OM2/blob/d907f3314a9956875baaaaf2b4d7b6be6fa81926/spack.yaml#L8) along with its [associated module projection](https://github.com/ACCESS-NRI/ACCESS-OM2/blob/d907f3314a9956875baaaaf2b4d7b6be6fa81926/spack.yaml#L51).<br>
+3. It is also recommended to update the [overall ACCESS-OM2 version](https://github.com/ACCESS-NRI/ACCESS-OM2/blob/d907f3314a9956875baaaaf2b4d7b6be6fa81926/spack.yaml#L8).<br>
    This is particularly important before merging a PR as it will determine the version tag for the model new release. The format is `CALVER_YEAR.CALVER_MONTH.MINOR`.<br>
    In this example, the overall version will be updated to `git.2024.03.1`.
 
@@ -136,14 +132,6 @@ should look like the following:
     <terminal-line lineDelay=0 class="git-cyan">@@ -48,8 +48,8 @@ spack:</terminal-line>
     <terminal-line lineDelay=0 class="keep-blanks">        - libaccessom2</terminal-line>
     <terminal-line lineDelay=0 class="keep-blanks">        - oasis3-mct</terminal-line>
-    <terminal-line lineDelay=0 class="keep-blanks">        projections:</terminal-line>
-    <terminal-line lineDelay=0 class="keep-blanks git-red">-          access-om2: '{name}/2024.03.0'</terminal-line>
-    <terminal-line lineDelay=0 class="keep-blanks git-green">+          access-om2: '{name}/2024.03.1'</terminal-line>
-    <terminal-line lineDelay=0 class="keep-blanks">        cice5: '{name}/2023.10.19-{hash:7}'</terminal-line>
-    <terminal-line lineDelay=0 class="keep-blanks git-red">-          mom5: '{name}/2023.11.09-{hash:7}'</terminal-line>
-    <terminal-line lineDelay=0 class="keep-blanks git-green">+          mom5: '{name}/development-{hash:7}'</terminal-line>
-    <terminal-line lineDelay=0 class="keep-blanks">        libaccessom2: '{name}/2023.10.26-{hash:7}'</terminal-line>
-    <terminal-line lineDelay=0 class="keep-blanks">        oasis3-mct: '{name}/2023.11.09-{hash:7}'</terminal-line>
 </terminal-window>
 
 To stage and commit the changes, run:


### PR DESCRIPTION
# ACCESS-Hive Docs

## Description

References issue https://github.com/ACCESS-NRI/build-cd/issues/169 and related PRs https://github.com/ACCESS-NRI/build-cd/pull/295 and https://github.com/ACCESS-NRI/model-deployment-template/pull/30.

Having to update both the version of a package and it's associated projection in a spack manifest has long been a source of errors for users, and having to update the CI to accommodate bends to the rules has been a maintenance problem for a while. 

I've updated `build-cd` so it now injects the relevant projections rather than a user having to do it. So I'm updating the docs to remove reference to projections entirely. Users can still do their own projections, but I don't think it should be part of the docs. 

## Type of change

Please delete options that are not relevant.

- [x] New link / content

## Checklist:

- [x] The new content is accessible and located in the appropriate section
- [x] My changes do not break navigation and do not generate new warnings
- [x] I have checked that the links are valid and point to the intended content
- [x] I have checked my code/text and corrected any misspellings

When your pull request is ready please [request a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review). 

Unless there is a specific person you want your PR to be reviewd by, please select the **WebOps team**: `ACCESS-NRI/WebOps`. This ensures the load for reviewing pull requests is shared equitably.
