### PR TITLE
Fix broken anchor links in run a model pages

### DIFF
--- a/docs/models/run-a-model/run-access-cm2.md
+++ b/docs/models/run-a-model/run-access-cm2.md
@@ -175,7 +175,7 @@ module load cylc7
 !!! warning
     _Cylc_ version >= `cylc7/24.03` required.<br>
     
-    Also, before loading the _Cylc_ module, make sure to have started a _persistent session_ and have assigned it to the {{ model }} workflow. For more information about these steps, refer to [Set up _persistent session_](#set-up-persistent-session).
+    Also, before loading the _Cylc_ module, make sure to have started a _persistent session_ and have assigned it to the {{ model }} workflow. For more information about these steps, refer to [Set up {{ model }} persistent session]({{ '#set-up-%s-persistent-session'%model.lower() }}).
 
 ### Rose setup {: #rose }
 [Rose](http://metomi.github.io/rose/doc/html/index.html) is a toolkit that can be used to view, edit, or run an ACCESS modelling suite.

--- a/docs/models/run-a-model/run-access-om2.md
+++ b/docs/models/run-a-model/run-access-om2.md
@@ -459,7 +459,7 @@ To enable syncing, change `enable` to `True`, and set `path` to a location on `/
 
 ### Pruning model restarts
 
-By default, {{ model }} saves restart files after each run, allowing subsequent simulations to resume from a previously saved model state. The default {{ model }} run length and restart period can be changed (see [Change run length and restart period](#change-run-length-and-restart-period)).<br>
+By default, {{ model }} saves restart files after each run, allowing subsequent simulations to resume from a previously saved model state. The default {{ model }} run length and restart period can be changed (see [Change run length](#change-run-length)).<br>
 However, restart files can occupy significant disk space, and keeping all of them throughout an entire experiment is often not necessary. If disk space is limited, consider using _payu_'s restart files pruning feature, controlled by the `restart_freq` field of the `config.yaml`.
 By default, every `restart_freq` _payu_ removes intermediate restart files, keeping only: 
 - the two most recent restarts

--- a/docs/models/run-a-model/run-access-om3.md
+++ b/docs/models/run-a-model/run-access-om3.md
@@ -151,7 +151,7 @@ To run the cloned {{ model }} configuration, execute the following command from 
     payu run
 
 This will submit a single job to the supercomputer "queue" with the default run length (1 year) specified in the configuration.<br>
-For information about changing the run length, refer to [Change run length](#change-run-length).
+For information about changing the run length, refer to [Change run length and restart period](#change-run-length-and-restart-period).
 
 <terminal-window>
     <terminal-line data="input">cd ~/access-om3/{{example_folder}}</terminal-line>


### PR DESCRIPTION
There were a few anchor links in the "run a model" pages that referred to incorrect headings, and were thus broken. One of the links on the CM2 page wasn't being templated, and was thus also broken.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue, e.g. dead links)

## Checklist:

- [x] The new content is accessible and located in the appropriate section
- [x] My changes do not break navigation and do not generate new warnings
- [x] I have checked that the links are valid and point to the intended content
- [x] I have checked my code/text and corrected any misspellings

When your pull request is ready please [request a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review). 

Unless there is a specific person you want your PR to be reviewd by, please select the **Hive Docs Team**: `ACCESS-NRI/hivedocsteam`. This ensures the load for reviewing pull requests is shared equitably.
