### PR TITLE
Bump resolve absolute urls plugin

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ mkdocs-git-revision-date-localized-plugin==1.4.5
 mkdocs-macros-plugin==1.3.7
 mkdocs-bibtex==4.4.0
 git+https://github.com/rbeucher/mkdocs_events_plugin.git
-git+https://github.com/ACCESS-NRI/mkdocs_resolve_absolute_urls_plugin.git@1.1.0
+git+https://github.com/ACCESS-NRI/mkdocs_resolve_absolute_urls_plugin.git@1.2.0


### PR DESCRIPTION
Bump the the [mkdocs_resolve_absolute_urls_plugin](https://github.com/ACCESS-NRI/mkdocs_resolve_absolute_urls_plugin) to version `1.2.0` allow absolute urls to be resolved even when present in `overrides` templates.

