### PR TITLE
Test. PR for RTD

### DIFF
--- a/.readthedocs/.readthedocs.yaml
+++ b/.readthedocs/.readthedocs.yaml
@@ -15,10 +15,10 @@ build:
   os: ubuntu-24.04
   tools:
     python: "3.13"
-  jobs:
-    post_checkout: 
-    # Cancel PR preview if the PR base is not the default branch - MODIFY IF NEEDED: comment if not needed
-    # - curl -s https://raw.githubusercontent.com/ACCESS-NRI/ACCESS-Hive-Docs/refs/heads/main/.readthedocs/scripts/cancel_pr_preview_if_base_not_default.sh | bash
+  # MODIFY IF NEEDED: uncomment lines below to cancel the RTD build
+  # jobs:
+  #   post_checkout: 
+  #     - exit 183
 
 
 # Build documentation with Mkdocs


### PR DESCRIPTION
Test PR to allow the job scripts to be downloaded from the Hive Docs repo instead of called locally with `bash <path_to_script>`, to avoid multiple scripts for different websites and instead having a single central repository (ACCESS-Hive-Docs) with all scripts.