### PR TITLE
:sparkles: (#1068): Added typo issue form

### DIFF
--- a/.github/ISSUE_TEMPLATE/typo-report.yml
+++ b/.github/ISSUE_TEMPLATE/typo-report.yml
@@ -1,4 +1,4 @@
-name: Typo Report
+name: ✏️ Typo Report
 description: Flag small corrections such as spelling, grammar, or minor formatting errors.
 labels: ['🪲 bug / mistake']
 title: '[TYPO]: '


### PR DESCRIPTION
Fixes the issue #1068 . Since we have a single label for both `typo` and `bug`, when a typo report is created, it adds the same label - `🪲 bug / mistake`.

Please feel free to review the wording and add suggestions :) 