### PR TITLE
RTD custom build

### DIFF
--- a/.readthedocs/.readthedocs.yaml
+++ b/.readthedocs/.readthedocs.yaml
@@ -21,9 +21,12 @@ build:
   os: ubuntu-24.04
   tools:
     python: "3.13"
-  # jobs:
-    # post_checkout: # MODIFY IF NEEDED: uncomment to cancel the RTD build
-    #   - exit 183
+  jobs:
+    # post_checkout: ['exit 183'] # MODIFY IF NEEDED: uncomment to cancel the RTD build
+    build:
+      html:
+        - curl -sSL https://raw.githubusercontent.com/ACCESS-NRI/ACCESS-Hive-Docs/davide/rtd_custom_build/.readthedocs/scripts/custom_build.sh | bash # Custom build
+    
 
 # Build documentation with Mkdocs
 mkdocs:

--- a/.readthedocs/.readthedocs.yaml
+++ b/.readthedocs/.readthedocs.yaml
@@ -25,7 +25,7 @@ build:
     # post_checkout: ['exit 183'] # MODIFY IF NEEDED: uncomment to cancel the RTD build
     build:
       html:
-        - curl -sSL https://raw.githubusercontent.com/ACCESS-NRI/ACCESS-Hive-Docs/davide/rtd_custom_build/.readthedocs/scripts/custom_build.sh | bash # Custom build
+        - curl -sSL https://raw.githubusercontent.com/ACCESS-NRI/ACCESS-Hive-Docs/main/.readthedocs/scripts/custom_build.sh | bash # Custom build
     
 
 # Build documentation with Mkdocs

--- a/.readthedocs/scripts/custom_build.sh
+++ b/.readthedocs/scripts/custom_build.sh
@@ -1,0 +1,57 @@
+# This is a custom build script for mkdocs that checks for the branch name and exports 
+# a EDIT_URI env variable to be used in the mkdocs build to set edit_uri to the proper branch, 
+# especially for PR preview builds.
+# If the build comes from a forked repo or from a tag, the EDIT_URI variable will not be set.
+# This is needed to avoid the link-check workflow to fail for new pages if the edit_uri points to 
+# a non-existing file in the main branch.
+
+set -e
+
+if [ "$READTHEDOCS_VERSION_TYPE" == external ]; then # PR preview build
+    # Download jq
+    export JQ_EXE=$(pwd)/jq
+    wget -q https://github.com/stedolan/jq/releases/latest/download/jq-linux64 -O "$JQ_EXE"
+    chmod +x "$JQ_EXE"
+    "$JQ_EXE" --version
+    # Get full repo
+    full_repo=$(sed -E 's|.*github\.com[:/](.+)$|\1|' <<< "$READTHEDOCS_GIT_CLONE_URL")
+    # Remove .git suffix if present
+    full_repo=${full_repo%.git}
+    # Get repo and owner
+    IFS='/' read owner repo <<< "$full_repo"
+    # Check if the PR comes from a forked repo
+    gh_api_url="https://api.github.com/repos/$owner/$repo"
+    pr_info=$(curl -s "$gh_api_url/pulls/$READTHEDOCS_GIT_IDENTIFIER")
+    pr_head_owner=$("$JQ_EXE" -r '.head.user.login' <<< "$pr_info")
+    if [ "$owner" == "$pr_head_owner" ]; then # Not a fork
+        # Get the branch name
+        branch_name=$("$JQ_EXE" -r '.head.ref' <<< "$pr_info")
+    fi
+elif git show-ref --heads "$READTHEDOCS_GIT_IDENTIFIER" --quiet; then # Branch build
+    branch_name="$READTHEDOCS_GIT_IDENTIFIER"
+fi
+
+# Download yq
+export YQ_EXE=$(pwd)/yq
+wget -q https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O "$YQ_EXE"
+chmod +x "$YQ_EXE"
+"$YQ_EXE" --version
+
+# Get RTD config path
+rtd_config_path=$(find "$READTHEDOCS_REPOSITORY_PATH" -type f \( -name ".readthedocs.yaml" -o -name ".readthedocs.yml" \))
+# Get mkdocs config path
+mkdocs_path=$("$YQ_EXE" '.mkdocs.configuration' "$rtd_config_path")
+if [ -n "$branch_name" ]; then
+    # Get docs_dir from mkdocs config or set to default 'docs'
+    docs_dir=$("$YQ_EXE" '.docs_dir // "docs"' "$mkdocs_path")
+    EDIT_URI="edit/$branch_name/$docs_dir"
+    echo "This is a branch build. EDIT_URI set to to '$EDIT_URI'"
+    export EDIT_URI
+fi
+
+# Default RTD mkdocs build commands
+echo ======= START OF mkdocs.yml =======
+cat "$mkdocs_path"
+echo ======= ENF OF mkdocs.yml =======
+cmd="python -m mkdocs build --clean --site-dir $READTHEDOCS_OUTPUT/html --config-file $mkdocs_path"
+eval "$cmd"

--- a/.readthedocs/scripts/custom_build.sh
+++ b/.readthedocs/scripts/custom_build.sh
@@ -10,7 +10,8 @@ set -e
 if [ "$READTHEDOCS_VERSION_TYPE" == external ]; then # PR preview build
     # Download jq
     export JQ_EXE=$(pwd)/jq
-    wget -q https://github.com/stedolan/jq/releases/latest/download/jq-linux64 -O "$JQ_EXE"
+    JQ_VERSION='jq-1.8.1'
+    wget -q https://github.com/stedolan/jq/releases/download/$JQ_VERSION/jq-linux64 -O "$JQ_EXE"
     chmod +x "$JQ_EXE"
     "$JQ_EXE" --version
     # Get full repo
@@ -33,7 +34,8 @@ fi
 
 # Download yq
 export YQ_EXE=$(pwd)/yq
-wget -q https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O "$YQ_EXE"
+YQ_VERSION='v4.50.1'
+wget -q https://github.com/mikefarah/yq/releases/download/$YQ_VERSION/yq_linux_amd64 -O "$YQ_EXE"
 chmod +x "$YQ_EXE"
 "$YQ_EXE" --version
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,7 +8,9 @@ site_url: !ENV READTHEDOCS_CANONICAL_URL
 repo_url: https://github.com/ACCESS-NRI/ACCESS-Hive-Docs
 repo_name: ACCESS-Hive-Docs
 
-edit_uri: edit/development/docs/
+edit_uri: !ENV [EDIT_URI, ""]
+# EDIT_URI is set within the website build (ReadTheDocs) through the ACCESS-Hive-Docs repo script
+# https://github.com/ACCESS-NRI/ACCESS-Hive-Docs/blob/main/.readthedocs/scripts/custom_build.sh
 
 theme:
   name: material


### PR DESCRIPTION
## Overview
Added custom build script to:
- dynamically set `edit_uri` at build time
- fix [link-checker issue with new pages and edit link](https://github.com/ACCESS-NRI/ACCESS-Hive-Docs/issues/1083#issuecomment-3609116967)

>[!NOTE]
> The current RTD build fails because the readthedocs config is trying to fetch for the `custom_build.sh` file in `main` (after https://github.com/ACCESS-NRI/ACCESS-Hive-Docs/pull/1096/commits/5ebff2cbd5dbe5d87e4290577020fd788c26b71d), but that file is added in this PR and therefore cannot be found in `main`. This is the setup that will work in production.
> A successful test using the script fetched from this PR head branch can be found [here](https://app.readthedocs.org/projects/access-hive-docs/builds/30561137/?utm_source=access-hive-docs&utm_content=notification).

## More information about implementation
Currently this PR sets a custom build script (`custom_build.sh`) to replace the default RTD `build` job. 
This is necessary as env variables cannot be passed from a custom RTD job to another (separate RTD jobs are run with brand new environments and cannot inherit the enviroment from a previous custom job). This is the reason why the `EDIT_URI` env variable cannot be set in a custom job before `build` (for example `post-checkout`) and passed to the default RTD build step.