### PR TITLE
Added redirections

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,6 +63,9 @@ plugins:
       separator: '[\s\-,:!=\[\]()"/]+|(?!\b)(?=[A-Z][a-z])|\.(?!\d)|&[lg]t;'
   - bibtex:
       bib_file: "references.bib"
+  - redirects:
+      redirect_maps:
+        'models/run_a_model/run_access-ram.md': 'models/run_a_model/run_access-ram3.md'
   - resolve-absolute-urls
   - macros
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ mkdocs-git-revision-date-localized-plugin==1.4.5
 mkdocs-macros-plugin==1.3.7
 mkdocs-bibtex==4.4.0
 git+https://github.com/ACCESS-NRI/mkdocs_resolve_absolute_urls_plugin.git@1.3.0
+mkdocs-redirects==1.2.2


### PR DESCRIPTION
Added mkdocs-redirects plugin and added the redirection from 'models/run_a_model/run_access-ram' to 'models/run_a_model/run_access-ram3'

https://access-hive-docs--1105.org.readthedocs.build/models/run_a_model/run_access-ram gets now correctly redirected.