### PR TITLE
Link error in Cryosphere Datapool page

### DIFF
--- a/docs/model_evaluation/data/cryosphere_datapool.md
+++ b/docs/model_evaluation/data/cryosphere_datapool.md
@@ -20,7 +20,7 @@ The Cryosphere Community Datapool (CCD) is a joint project between ACCESS-NRI an
 ## Prerequisites
 
 - **NCI Account**
-    To access the CCD, you need to [Set Up your NCI Account](https://docs.access-hive.org.au/pr-previews/1063/getting_started/set_up_nci_account).
+    To access the CCD, you need to [Set Up your NCI Account](https://docs.access-hive.org.au/getting_started/set_up_nci_account).
 
 - **Join NCI projects**
     Join the following projects by requesting membership on their respective NCI project pages:


### PR DESCRIPTION
## Description
Following merge of pr #1063 theres a link error from using the pr-preview

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue, e.g. dead links)

