### PR TITLE
Fixed typos in rAM3 docs 

### DIFF
--- a/docs/models/run_a_model/run_access-ram3.md
+++ b/docs/models/run_a_model/run_access-ram3.md
@@ -117,6 +117,7 @@ This quick guide outlines the basic steps to run {{ model }} and is tailored to 
     ```
     This step can be carried out simultaneously with step 8.
 10. **Run the RNS**
+    
     This step must be carried out only after step 8 (optional) and 9 have successfully completed.
     ```
     rose suite-run -C ~/roses/{{ rns_id }}


### PR DESCRIPTION
Fixed broken link and typos in Run ACCESS-rAM3 docs 

Fixes #1117

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue, e.g. dead links)
