### PR TITLE
Very minor tweaks to the spack install page to link to the Modify and build an ACCESS model source code doc 

### DIFF
--- a/docs/getting_started/spack.md
+++ b/docs/getting_started/spack.md
@@ -10,7 +10,7 @@ To use _Spack_, please familiarise yourself with the [Basic Usage instructions](
 
 We also recommend that you refer to the [Spack 101 Tutorial](https://spack-tutorial.readthedocs.io/en/latest/).
 
-Installing _Spack_ allows users to build ACCESS models directly from the source code and carry out development testing that involves modifying the source code.<br>
+Installing _Spack_ allows users to build ACCESS models directly from the source code, swap model components, and carry out development testing that involves modifying the source code.<br>
 After installing _Spack_, refer to the [Build a model](https://docs.access-hive.org.au/models/build_a_model/build_source_code/) page for the next steps.
 
 ## Prerequisites


### PR DESCRIPTION
Minor tweaks to the spack install page. I found today that there wasn't an obvious link between what one can do next after installing spack. Added a few references to that effect ([this page](https://docs.access-hive.org.au/models/build_a_model/build_source_code/)).

(Great to have the pencil to click on, definitely buoyed my enthusiasm for putting in a PR 😄 !)