### PR TITLE
Add "Basics of ACCESS Data" section

### DIFF
--- a/docs/model_evaluation/data/data_basics.md
+++ b/docs/model_evaluation/data/data_basics.md
@@ -1,0 +1,49 @@
+# Basics of ACCESS Data
+
+### Structured data from gridded climate models
+
+ACCESS climate models simulate the Earth system on three-dimensional grids, representing longitude, latitude, and height or depth. These simulations evolve over time, so model output is often four-dimensional (for example: longitude × latitude × depth × time).
+
+Because of this, ACCESS model output is highly structured. Each dataset contains many variables (such as temperature, wind, or precipitation), each defined on specific grids and time intervals. Preserving this structure is essential for correctly interpreting and analysing the data.
+
+
+### NetCDF: data and metadata
+
+ACCESS model data is typically stored in **[netCDF (Network Common Data Form)](https://www.unidata.ucar.edu/software/netcdf)** files. NetCDF is well suited to climate and geoscience data because it stores:
+
+- the data values themselves 
+- metadata that describe what the data represent
+
+Metadata includes information such as variable names, units, grid definitions, coordinate systems, and time conventions. This context is critical: without it, the raw numbers in a dataset are difficult to interpret or use correctly.
+
+
+
+#### What’s inside a netCDF file?
+
+A netCDF file is more than a container of numbers. It explicitly defines:
+
+- **dimensions** (e.g. longitude, latitude, time, levels)  
+- **variables** (data arrays associated with those dimensions)  
+- **attributes** (metadata describing variables and the dataset as a whole)
+
+Tools such as `ncdump` allow users to inspect this structure directly, showing how variables are defined and how metadata is stored alongside the data. This self-describing nature is a key strength of netCDF.
+
+
+
+### CF conventions
+
+Most ACCESS netCDF files follow the **[Climate and Forecast (CF) metadata conventions](https://cfconventions.org)**. CF conventions provide standardised ways to describe:
+
+- coordinates and grids  
+- physical quantities and units  
+- time and calendar definitions  
+
+These conventions make datasets easier for humans to understand and machines to interpret. Many analysis and visualisation tools (such as [Xarray](https://xarray.dev)) rely on CF conventions to automatically recognise coordinates, apply units correctly, and handle data consistently across different models and datasets.
+
+
+
+### Large datasets: chunks
+
+ACCESS model output can be very large, often spanning many files and many terabytes of data. To support efficient access and analysis, data is often stored in chunks — smaller blocks of data organised within files.
+
+Chunking allows analysis tools to read only the portions of data needed for a given task, rather than loading entire datasets into memory. While largely invisible to end users, chunking is an important concept when working with large-scale model output.

--- a/docs/model_evaluation/data/index.md
+++ b/docs/model_evaluation/data/index.md
@@ -1,5 +1,7 @@
 # Data
 
+### Basics of ACCESS Data
+
 ### Finding ACCESS Data
 
 This is where we put links to our new pages on `Finding ACCESS Data`

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -141,6 +141,7 @@ nav:
     - model_evaluation/index.md
     - Data:
       - model_evaluation/data/index.md
+      - Basics of ACCESS Data: model_evaluation/data/data_basics.md
       - Cryosphere Community Datapool: model_evaluation/data/cryosphere_datapool.md
     - Model Evaluation: 
       - model_evaluation/evaluation_on_gadi/index.md


### PR DESCRIPTION
## Description

This PR adds the "Basics of ACCESS Data" section, including brief information on climate model output structure and format.

Part of issue #1124 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue, e.g. dead links)
- [x] New link / content

## Checklist:

- [ ] The new content is accessible and located in the appropriate section
- [ ] My changes do not break navigation and do not generate new warnings
- [ ] I have checked that the links are valid and point to the intended content
- [ ] I have checked my code/text and corrected any misspellings

