### PR TITLE
Remove ssh key step in Run ACCESS-rAM3 page

### DIFF
--- a/docs/models/run_a_model/run_access-ram3.md
+++ b/docs/models/run_a_model/run_access-ram3.md
@@ -138,9 +138,6 @@ Connect to _Gadi_ by following the [related instructions in the _Rose/Cylc_ page
 
 Set up a persistent session by following the [related instructions on the _Rose/Cylc_ page](/models/run_a_model/rose_cylc/#set-up-a-persistent-session).
 
-### Set up SSH-keys (once-only) {: .no-toc }
-
-Follow the [initialisation step](https://opus.nci.org.au/spaces/DAE/pages/249495793/Run+Cylc7+Suites#RunCylc7Suites-InitialisationStep(once-onlyforaccessdevcompatible-mode)) to accurately set up your ssh keys so you can run the model from outside of the persistent session.
 
 ### Set up Rose/Cylc
 


### PR DESCRIPTION
## Description

This removes the section about setting up the ssh key for running rAM3, after a discussion with @engelca, @penguian, and others.

Note that we will need to add the ssh key setup steps elsewhere, as this step will still be required when building the model. I will confirm with @engelca, @penguian, and @atteggiani where it best makes sense to include this information on the Hive Docs in a future issue/PR.  

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue, e.g. dead links)
- [ ] New link / content

## Checklist:

- [ ] The new content is accessible and located in the appropriate section
- [ ] My changes do not break navigation and do not generate new warnings
- [ ] I have checked that the links are valid and point to the intended content
- [ ] I have checked my code/text and corrected any misspellings


