### PR TITLE
Fixed other american spelling '-ize-' to English spelling '-ise-'

### DIFF
--- a/docs/community_resources/workshops_events_archive/access_workshop_2024/training_materials.md
+++ b/docs/community_resources/workshops_events_archive/access_workshop_2024/training_materials.md
@@ -83,7 +83,7 @@ You can find this information by viewing your Eventbrite ticket, which you can f
 You should receive automated emails from NCI as your memberships are approved. You can also check on the status of your project memberships by logging into MyNCI.  
  
 ### Wondering why you have to join so many NCI projects? 
-NCI compute and storage space is organized into projects. In order to get access to our Training Day compute resources, you will need access to project nf33. Most of the other projects listed above are for accessing datasets and/or software tools that are stored at NCI in specific projects. For instance, oi10 and fs38 house CMIP6 datasets. 
+NCI compute and storage space is organised into projects. In order to get access to our Training Day compute resources, you will need access to project nf33. Most of the other projects listed above are for accessing datasets and/or software tools that are stored at NCI in specific projects. For instance, oi10 and fs38 house CMIP6 datasets. 
  
 ### Training Day program and other information 
 - [Link to Training Day information on the ACCESS-NRI website](https://www.access-nri.org.au/event/access-training-day-2-september-2024/)

--- a/docs/model_evaluation/community_med/community_med_recipes.md
+++ b/docs/model_evaluation/community_med/community_med_recipes.md
@@ -180,7 +180,7 @@ IOMB uses the same code base as the International Land Model Benchmarking (ILAMB
     <div align='center' width="100%" >
         <a href="https://pcmdi.github.io/pcmdi_metrics/index.html" target="_blank">Documentation</a> |
         <a href="https://github.com/PCMDI/pcmdi_metrics" target="_blank">Source Code</a>
-        <!-- The PMP is used to provide “quick-look” objective comparisons of Earth System Models (ESMs) with one another and available observations. Results are produced in the context of all model simulations contributed to CMIP6 and earlier CMIP phases. Currently, the comparisons emphasize metrics of large- to global-scale annual cycle and both tropical and extra-tropical modes of variability. Ongoing work in v1.x development branches include established statistics for ENSO, MJO, regional monsoons, and high frequency characteristics of simulated precipitation. -->
+        <!-- The PMP is used to provide “quick-look” objective comparisons of Earth System Models (ESMs) with one another and available observations. Results are produced in the context of all model simulations contributed to CMIP6 and earlier CMIP phases. Currently, the comparisons emphasise metrics of large- to global-scale annual cycle and both tropical and extra-tropical modes of variability. Ongoing work in v1.x development branches include established statistics for ENSO, MJO, regional monsoons, and high frequency characteristics of simulated precipitation. -->
     </div>
 </td>
 </tr>
@@ -274,7 +274,7 @@ IOMB uses the same code base as the International Land Model Benchmarking (ILAMB
         <a href="https://github.com/noaa-oar-arl/monet" target="_blank">Source Code</a> |
         <a href="https://www.mdpi.com/2073-4433/8/11/210" target="_blank">Paper</a>
         <!-- MONET is an open source project and Python package that aims to create a common platform for atmospheric composition data analysis for weather and air quality models.
-        MONET was developed to evaluate the Community Multiscale Air Quality Model (CMAQ) for the NOAA National Air Quality Forecast Capability (NAQFC) modeling system. MONET is designed to be a modularized Python package for (1) pairing model output to observational data in space and time; (2) leveraging the Pandas Python package for easy searching and grouping; and (3) analyzing and visualizing data. This process introduces a convenient method for evaluating model output. -->
+        MONET was developed to evaluate the Community Multiscale Air Quality Model (CMAQ) for the NOAA National Air Quality Forecast Capability (NAQFC) modeling system. MONET is designed to be a modularised Python package for (1) pairing model output to observational data in space and time; (2) leveraging the Pandas Python package for easy searching and grouping; and (3) analyzing and visualizing data. This process introduces a convenient method for evaluating model output. -->
     </div>
 </td>
 </tr>

--- a/docs/model_evaluation/index.md
+++ b/docs/model_evaluation/index.md
@@ -43,9 +43,9 @@ While this work is in progress, you can refer to a collection of links to existi
 
 ## TBD: CMORisation
 
-TBD: Raw data vs. curated data: CMORized vs. not! What does CMORized actually mean (look at ESMValTool documentation)?
+TBD: Raw data vs. curated data: CMORised vs. not! What does CMORised actually mean (look at ESMValTool documentation)?
 TBD: Add APP4 to navigation (replace **Model Format Processing**?)
 TBD: Tools to check if data is CMOR-compliant (raise issue)
-TBD: Discuss with Dougie: How can we identify what is CMORized and what is not?
+TBD: Discuss with Dougie: How can we identify what is CMORised and what is not?
 
 -->

--- a/docs/models/access_models/index.md
+++ b/docs/models/access_models/index.md
@@ -1,7 +1,7 @@
 # ACCESS Models
 
 ACCESS models are computer programs that represent key components of the Earth's climate system, including the atmosphere, oceans, land surface, and sea ice. These models use complex mathematical equations to simulate past, present, and future weather and climate conditions, as well as idealised scenarios. Different ACCESS models are configured with varying combinations of Earth system components to address specific research needs.<br>
-Developed in collaboration with international climate modeling institutions, these models are optimized for Australia’s high-performance computing (HPC) systems and tailored for Australian researchers.
+Developed in collaboration with international climate modeling institutions, these models are optimised for Australia’s high-performance computing (HPC) systems and tailored for Australian researchers.
 
 Below is a list of ACCESS models supported by ACCESS-NRI.
 

--- a/docs/models/build_a_model/create_a_prerelease.md
+++ b/docs/models/build_a_model/create_a_prerelease.md
@@ -211,7 +211,7 @@ If the PR gets merged, an official ACCESS-NRI release build of the given model w
 
 ## Draft vs non-draft PR
 The prerelease build workflow used to [trigger model prereleases](#trigger-model-prerelease-and-release-build-deployments) differs depending on whether the open PR is a _draft_ or a _regular_ PR.
-The differences are summarized in the table below:
+The differences are summarised in the table below:
 
 |**Type**|**Used for**|**CI Checks**|
 |---|---|---|


### PR DESCRIPTION
Updated another american spelling: `-ize-` has been changed to `-ise-`.

Not I left all instances (and similar variations) of `concretize` as is (NOT corrected to `concretise`), because that is part of a _Spack_ command (`spack concretize`), so to avoid confusion I left them all in the american spelling.