### PR TITLE
Copyright year hook

### DIFF
--- a/docs/hooks/copyright_year.py
+++ b/docs/hooks/copyright_year.py
@@ -1,0 +1,6 @@
+## This hook updates the copyright year in the site configuration to the current year.
+from datetime import datetime
+
+def on_config(config, **kwargs):
+    year: str = str(datetime.now().year)
+    config.copyright = config.copyright.format(year=year)

--- a/docs/hooks/copyright_year.py
+++ b/docs/hooks/copyright_year.py
@@ -4,3 +4,4 @@ from datetime import datetime
 def on_config(config, **kwargs):
     year: str = str(datetime.now().year)
     config.copyright = config.copyright.format(year=year)
+    

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,7 +53,9 @@ theme:
   icon:
     edit: material/pencil
     view: material/eye
-copyright: Copyright &copy; 2025 ACCESS-NRI
+hooks:
+  - docs/hooks/copyright_year.py
+copyright: Copyright &copy; {year} ACCESS-NRI
 
 plugins:
   - git-revision-date-localized:


### PR DESCRIPTION
## Description
Update copyright year to use current year.

Following this [example in discussion](https://github.com/squidfunk/mkdocs-material/discussions/4969#discussioncomment-7290363)
Using [python hooks](https://www.mkdocs.org/user-guide/configuration/#hooks) which I put in a folder in `docs`

Fixes #739 


## Type of change

- [x] updates copyright year in config

## Checklist:

- [x] served locally and working

