### PR TITLE
Add link to WOMBAT docs

### DIFF
--- a/docs/models/model_components/bgc_ocean.md
+++ b/docs/models/model_components/bgc_ocean.md
@@ -6,6 +6,9 @@
 
 The World Ocean Model of Biogeochemistry And Trophic-dynamics (WOMBAT) is the ocean biogeochemistry module added to ACCESS models. The core of WOMBAT is a Nutrient, Phytoplankton, Zooplankton and Detritus (NPZD) cycle. WOMBAT simulates the evolution of open-ocean phosphate, oxygen, dissolved inorganic carbon, alkalinity, iron and carbon fluxes with one zooplankton and one phytoplankton class.
 
+For full details, see the [WOMBAT documentation](https://wombat-docs.readthedocs.io/stable/).
+
 ### Models that use WOMBAT
 - [ACCESS-OM2](/models/access_models/access-om#access-om2) (within [MOM](/models/model_components/ocean#modular-ocean-model-mom))
 - [ACCESS-ESM1.5](/models/access_models/access-esm#access-esm15) (within [MOM](/models/model_components/ocean#modular-ocean-model-mom))
+- [ACCESS-OM3](/models/access_models/access-om#access-om3) (within [MOM](/models/model_components/ocean#modular-ocean-model-mom))

--- a/docs/models/model_components/bgc_ocean.md
+++ b/docs/models/model_components/bgc_ocean.md
@@ -4,7 +4,7 @@
 
 ## WOMBAT
 
-The World Ocean Model of Biogeochemistry And Trophic-dynamics (WOMBAT) is the ocean biogeochemistry module added to ACCESS models. The core of WOMBAT is a Nutrient, Phytoplankton, Zooplankton and Detritus (NPZD) cycle. WOMBAT simulates the evolution of open-ocean phosphate, oxygen, dissolved inorganic carbon, alkalinity, iron and carbon fluxes with one zooplankton and one phytoplankton class.
+The World Ocean Model of Biogeochemistry And Trophic-dynamics (WOMBAT) is the ocean biogeochemistry module added to ACCESS models. The core of WOMBAT is a Nutrient - Phytoplankton - Zooplankton - Detritus (NPZD) model. WOMBAT simulates the biogeochemical cycles of nitrate, iron, oxygen, carbon, alkalinity and calcium carbonate in the open ocean. Its ecosystem component consists of one phytoplankton, zooplankton and detrital functional type. It tracks chlorophyll concentration within phytoplankton and iron within all three organic pools.
 
 For full details, see the [WOMBAT documentation](https://wombat-docs.readthedocs.io/stable/).
 

--- a/docs/models/model_components/bgc_ocean.md
+++ b/docs/models/model_components/bgc_ocean.md
@@ -9,6 +9,7 @@ The World Ocean Model of Biogeochemistry And Trophic-dynamics (WOMBAT) is the oc
 For full details, see the [WOMBAT documentation](https://wombat-docs.readthedocs.io/stable/).
 
 ### Models that use WOMBAT
+
+- [ACCESS-OM3](/models/access_models/access-om#access-om3) (within [MOM](/models/model_components/ocean#modular-ocean-model-mom/#mom6))
 - [ACCESS-OM2](/models/access_models/access-om#access-om2) (within [MOM](/models/model_components/ocean#modular-ocean-model-mom))
 - [ACCESS-ESM1.5](/models/access_models/access-esm#access-esm15) (within [MOM](/models/model_components/ocean#modular-ocean-model-mom))
-- [ACCESS-OM3](/models/access_models/access-om#access-om3) (within [MOM](/models/model_components/ocean#modular-ocean-model-mom))


### PR DESCRIPTION
# ACCESS-Hive Docs

## Description

Adds a link to the WOMBAT documentation on the WOMBAT page of Hive Docs, and adds ACCESS-OM3 as a model that uses WOMBAT.

Fixes #1122 


