### PR TITLE
Added permalink anchor

### DIFF
--- a/docs/css/access-nri.css
+++ b/docs/css/access-nri.css
@@ -941,7 +941,6 @@ details.code {
   scroll-margin-top: 7rem !important;
 }
 
-
 /* Tab section */
 .md-tabs {
   background-color: var(--md-primary-fg-color--dark);

--- a/docs/js/miscellaneous.js
+++ b/docs/js/miscellaneous.js
@@ -1,5 +1,41 @@
 'use strict';
 
+// Use the mkdocs-material way to show a notification at the bottom of the screen
+// exploiting the md-dialog class enabled by the code.code.copy feature (needs to be enabled in mkdocs.yaml)
+// https://squidfunk.github.io/mkdocs-material/reference/code-blocks/#code-copy-button
+const notification = document.querySelector('.md-dialog > .md-dialog__inner');
+function showNotification(text) {
+    notification.innerHTML = text;
+    notification.parentElement.classList.add("md-dialog--active");
+    setTimeout(function () {
+        notification.parentElement.classList.remove("md-dialog--active");
+    }, 2000);
+}
+
+// Set up permalinks (clickable symbol shown when headers are hovered over):
+// - Remove their default behaviour of linking to themselves (treat them as buttons instead of links)
+// - Copy the URL to clipboard when clicking on it
+// - Change symbol to custom one 
+function setUpPermalinks() {
+    document.querySelectorAll(".headerlink").forEach(function (link) {
+        let permalink = link.href;
+        // Replace the link behaviour by replacing it with a <span> element
+        const span = document.createElement("span");
+        Array.from(link.attributes).forEach(attr => {
+            if (attr.name !== "href") span.setAttribute(attr.name, attr.value);
+        });
+        span.innerHTML = '<i class="fa-solid fa-link fa-xs"></i>'; // Link icon from fontawesome
+        link.replaceWith(span);
+        span.style.cursor = "pointer";
+        span.addEventListener("click", function () {
+            // Copy permalink to clipboard
+            navigator.clipboard.writeText(permalink);
+            // Show "Copied to clipboard" notification
+            showNotification("Copied to clipboard");
+        });
+    });
+}
+
 // Hide Table of Content items whose related paragraph has the 'no-toc' class
 function hideTocItems() {
   document.querySelectorAll('[aria-label="On this page"] .md-nav__item').forEach(item => {
@@ -318,6 +354,7 @@ function main() {
   fitText();
   toggleTerminalAnimations();
   makeCitationLinks();
+  setUpPermalinks();
 }
 
 // Run all functions after every navigation event

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -98,6 +98,8 @@ markdown_extensions:
   - tables
   - toc:
       title: On this page
+      permalink: true
+      permalink_title: Copy permalink to clipboard
 
 # Navigation
 nav:


### PR DESCRIPTION
Added permalink anchor to copy headers URL to clipboard when clicked.
- [x] Added `permalink: true` and `permalink_title` arguments to the `toc` markdown extension in the `mkdocs.yaml` to enable permalinks
- [x] Update `miscellaneous.js` to include `setUpPermalinks` and `showNotification` functions, to change the behaviour of permalinks (from actual links to buttons that copy the URL to clipboard when clicked)