### PR TITLE
spack.md: update instructions to use shared Spack instance

### DIFF
--- a/docs/getting_started/spack.md
+++ b/docs/getting_started/spack.md
@@ -1,93 +1,79 @@
-!!! danger
-    This page is tailored to experienced users and collaborators developing ACCESS models.<br>
-    This step is *not* required if you *only* want to run a model. If you are looking for information on how to run a model, refer to the [Run a Model](/models/run_a_model) section.
+!!! warning
+    **20/05/2026:** If you previously set up a personal _Spack_ instance by following the instructions on this page, note that the recommended method for enabling _Spack_ on _Gadi_ has changed. Please review the updated instructions below.
 
-!!! tip
-    **13/02/2026:** ACCESS-NRI has migrated from *Spack* `v0.22` to *Spack* `v1.1`. If you previously followed these instructions to set up *Spack* `v0.22`, you will need to repeat the setup process below to install *Spack* `v1.1`.
+# How to use Spack on Gadi for building ACCESS models
 
-# Set up Spack for building ACCESS models
+[Spack](https://spack.io/about/) is a build-from-source package manager, specifically designed to simplify the installation of scientific software on supercomputers. _Spack_ allows users to build ACCESS models directly from the source code, swap model components, and carry out development testing that involves modifying the source code.
 
-[Spack](https://spack.io/about/) is a build-from-source package manager, specifically designed to simplify the installation of scientific software on supercomputers.
+ACCESS-NRI has installed and configured a shared _Spack_ instance on _Gadi_ so that users do *not* need to create and maintain their own _Spack_ instance.
 
-To use _Spack_, please familiarise yourself with the [Basic Usage instructions](https://spack.readthedocs.io/en/latest/basic_usage.html) and [Environments](https://spack.readthedocs.io/en/latest/environments.html).
-
-We also recommend that you refer to the [Spack 101 Tutorial](https://spack-tutorial.readthedocs.io/en/latest/).
-
-Installing _Spack_ allows users to build ACCESS models directly from the source code, swap model components, and carry out development testing that involves modifying the source code.<br>
-After installing _Spack_, refer to the [Build a model](https://docs.access-hive.org.au/models/build_a_model/build_source_code/) page for the next steps.
+To use _Spack_, please familiarise yourself with the [essential Spack commands](https://spack.readthedocs.io/en/latest/package_fundamentals.html) used for [Listing Available Packages](https://spack.readthedocs.io/en/latest/package_fundamentals.html#listing-available-packages) and [Seeing Installed Packages](https://spack.readthedocs.io/en/latest/package_fundamentals.html#seeing-installed-packages). Alternatively, follow the instructions in the [Test Spack](#test-spack-optional) section below.
 
 ## Prerequisites
 - **NCI Account**<br> 
     These instructions are tailored specifically for _Gadi_. To use _Spack_ on _Gadi_, you need to [Set Up your NCI Account](/getting_started/set_up_nci_account).
-- **_Bash_ shell**<br>
-    The following instructions must be run in a _Bash_ shell, which is the default shell on _Gadi_.
-    To check if you are using _Bash_, run:
-    ```
-    echo "$BASH_VERSION"
-    ```
-    If you see output (i.e. the _Bash_ version), you are already in a Bash shell. If there is no output, start a _Bash_ shell by running:
-    ```
-    bash
-    ```
-{: #bash_shell }
-
-## Set up Spack on Gadi
-
-!!! tip
-    The steps in this section only need to be completed once.
-
-### Create a directory for Spack
-
-Create a directory on the filesystem where _Spack_ will be installed (e.g. `/g/data/$PROJECT/$USER/spack/1.1`). Use the `/g/data` filesystem if you wish to run the binaries on the compute nodes.
-
-```
-mkdir -p /g/data/$PROJECT/$USER/spack/1.1
-cd /g/data/$PROJECT/$USER/spack/1.1
-```
-
-### Clone the relevant git repositories
-
-!!! info
-    ACCESS-NRI maintains a [fork of Spack](https://github.com/ACCESS-NRI/spack) to enable back-porting fixes from more recent spack versions. This fork is the one used in these instructions.
-
-```
-git clone https://github.com/ACCESS-NRI/spack.git --branch access/releases/v1.1
-git clone https://github.com/ACCESS-NRI/spack-config.git --branch main
-```
-
-!!! success
-    Your _Spack_ setup is complete!
-
-For instructions on how to build an ACCESS model using _Spack_, refer to [Modify and build an ACCESS model's source code](/models/build_a_model/build_source_code).
 
 ## Enable Spack
 
-!!! warning
-    For this step, it is recommended to use a new login [_Bash_ shell environment](#bash_shell) to avoid conflicting environment variables. 
-    Additionally, this step must be repeated for every new login or new shell session.
-
-```
-cd /g/data/$PROJECT/$USER/spack/1.1
-module purge
-. spack/share/spack/setup-env.sh
-```
+Estimated time to complete: 1 minute
 
 !!! warning
-    There is a space between the `.` and the path to the file, as we are sourcing the file.
+    The ACCESS-NRI shared Spack instance is configured to use `/g/data/$PROJECT/$USER/spack/$SPACK_VERSION` for temporary and permanent files. If your default project ID changes, then _Spack_ will not be using the temporary and permanent files created with your previous project ID. This is particularly relevant for _Spack_ workflows run through PBS jobs using multiple projects.
+
+```
+module use /g/data/vk83/modules
+module load spack
+```
+
+!!! tip
+    Please refer to the [ACCESS-NRI Spack Cheat Sheet](https://forum.access-hive.org.au/t/access-nri-spack-cheat-sheet/5942) for further help on _Spack_.
 
 ## Test Spack (OPTIONAL)
 
-To test that your Spack installation works as expected, we will create an `ACCESS-TEST` environment and build the relevant packages (this will take approximately 30 minutes). Then, we will uninstall all the packages and remove the environment.
+<!--
+Wed May 13 14:18:53 AEST 2026
+- setup environment
+- concretize
+Wed May 13 14:25:55 AEST 2026
+- install
+Wed May 13 14:57:32 AEST 2026
+- cleanup
+Wed May 13 14:58:55 AEST 2026
+-->
 
+<!-- When the access-toolchain is defined and installed, we need to update the time it takes because it should be quicker. -->
+
+Estimated time to complete: 40 minutes
+
+To test that _Spack_ works as expected, clone the `ACCESS-TEST` repository and use it as a _Spack_ `independent environment` to install the relevant packages. The _Spack_ environment rules are defined in the `ACCESS-TEST/spack.yaml` file. If the packages are already installed in an [upstream](https://spack.readthedocs.io/en/latest/chain.html) they will not be rebuilt.
+
+### Find all installed Spack packages
+
+```
+spack find
+```
+
+### Find all local Spack packages
+
+```
+spack find --install-tree local
+```
+
+### Find all upstream Spack packages
+
+```
+spack find --install-tree upstream
+```
 
 ### Clone a Spack environment
 
+Change directory (`cd`) to the location where you want the `ACCESS-TEST` repository to reside. For example, `/g/data/$PROJECT/$USER/`
 ```
 git clone https://github.com/ACCESS-NRI/ACCESS-TEST.git
 ```
 
 ### Activate the environment
-Activate the `ACCESS-TEST` _Spack_ environment by running:
+Activate the _Spack_ environment inside the `ACCESS-TEST` directory by running:
 ```
 spack env activate -p ./ACCESS-TEST
 ```
@@ -98,27 +84,22 @@ spack env activate -p ./ACCESS-TEST
 
 ### Compile packages
 
+<!-- When Spack implements a command to disable and re-enable Spack upstreams, we should consider providing that information here -->
+
+!!! warning
+    Some of the commands below might take several minutes to complete.
+
 ```
-spack find
-spack concretize -f --fresh
+spack concretize -f
 spack install
 ```
 
-!!! warning
-    Some of the commands above might take several minutes to complete.
+!!! tip
+    To understand the Spack concretization output, refer to: [What do the symbols at the start of spack concretize output mean?](https://forum.access-hive.org.au/t/access-nri-spack-cheat-sheet/5942#p-20566-what-do-the-symbols-at-the-start-of-spack-concretize-output-mean-17)
 
 <terminal-window lineDelay=0>
-    <!-- spack find -->
-    <terminal-line directory="[test]" class="spack" data="input" lineDelay=600>spack find</terminal-line>
-    <terminal-line lineDelay=500><span class="spack-indigo">\==></span> In environment &lt;/path/to/environment/ACCESS-TEST&gt;</terminal-line>
-    <terminal-line><span class="spack-indigo">\==></span> 1 root specs</terminal-line>
-    <terminal-line>-- <span class="spack-pink">no arch</span> / <span class="spack-green">no compilers</span> ---------------------------------------</terminal-line>
-    <terminal-line><span class="spack-grey keep-blanks"> - </span> access-test</terminal-line>
-    <terminal-line></terminal-line>
-    <terminal-line><span class="spack-indigo">\==></span> 0 installed packages</terminal-line>
-    <terminal-line><span class="spack-indigo">\==></span> 0 concretized packages to be installed (show with `spack find -c`)</terminal-line>
     <!-- spack concretize -->
-    <terminal-line lineDelay=600 directory="[test]" class="spack" data="input">spack concretize -f --fresh</terminal-line>
+    <terminal-line lineDelay=600 directory="[test]" class="spack" data="input">spack concretize -f</terminal-line>
     <terminal-line>...</terminal-line>
     <terminal-line lineDelay=2000><span class="spack-indigo">\==></span> Concretized 1 spec:</terminal-line>
     <terminal-line>
@@ -174,12 +155,12 @@ spack install
 ### Check installed packages
 
 ```
-spack find
+spack find --install-tree local
 ```
 
 <terminal-window lineDelay=0>
     <!-- spack find -->
-    <terminal-line directory="[test]" class="spack" data="input" lineDelay=600>spack find</terminal-line>
+    <terminal-line directory="[test]" class="spack" data="input" lineDelay=600>spack find --install-tree local</terminal-line>
     <terminal-line lineDelay=500><span class="spack-indigo">\==></span> In environment &lt;/path/to/environment/ACCESS-TEST&gt;</terminal-line>
     <terminal-line><span class="spack-indigo">\==></span> 1 root specs</terminal-line>
     <terminal-line>-- <span class="spack-pink">no arch</span> / <span class="spack-green">no compilers</span> ---------------------------------------</terminal-line>
@@ -199,7 +180,7 @@ spack find
     </terminal-line>
     <terminal-line>...</terminal-line>
     <terminal-line><span class="spack-indigo">\==></span> &lt;N&gt; installed packages</terminal-line>
-    <terminal-line><span class="spack-indigo">\==></span> 0 concretized packages to be installed (show with `spack find -c`)</terminal-line>
+    <terminal-line><span class="spack-indigo">\==></span> 0 concretized packages to be installed (show with &#96;spack find -c&#96;)</terminal-line>
 </terminal-window>
 
 !!! info
@@ -212,20 +193,15 @@ spack env deactivate
 rm -rf ACCESS-TEST
 ```
 
-## Update Spack on Gadi
+## Develop a Model
 
-Keep your _Spack_ instance up-to-date by doing the following:
+For instructions on how to build an ACCESS model using _Spack_, refer to [Modify and build an ACCESS model's source code](/models/build_a_model/build_source_code).
 
-```
-cd /g/data/$PROJECT/$USER/spack/1.1
-find spack/etc/spack -type l -name '*.yaml' -exec rm {} \;
-git -C spack fetch --all -Pp
-git -C spack switch access/releases/v1.1
-git -C spack reset --hard origin/access/releases/v1.1
-git -C spack-config pull
-. spack/share/spack/setup-env.sh
-spack repo update
-```
+## Advanced users
+
+Please refer to [ACCESS-NRI's Spack configuration](https://github.com/ACCESS-NRI/spack-config) for details on how the release and shared _Spack_ instances are installed and configured.
+
+To use _Spack_ outside of _Gadi_, please refer to the [Spack 101 Tutorial](https://spack-tutorial.readthedocs.io/en/latest/).
 
 <custom-references>
 - [https://spack.readthedocs.io/en/latest/](https://spack.readthedocs.io/en/latest/)


### PR DESCRIPTION
The documentation that needs updating as part of https://github.com/ACCESS-NRI/spack-config/issues/41

We need to lock down filesystem permissions for the `spack-shared` directory on Gadi before merging this PR.