### PR TITLE
Added website-wide abbreviation glossary

### DIFF
--- a/abbreviations.md
+++ b/abbreviations.md
@@ -1,1 +1,2 @@
 *[UKMO]: UK MetOffice
+*[ESM]: Earth System Model

--- a/abbreviations.md
+++ b/abbreviations.md
@@ -8,3 +8,4 @@
 *[HPC]: High-Performance Computing
 *[NCI]: (Australian) National Computational Infrastructure
 *[ARE]: Australian Research Environment
+*[COSIMA]: Consortium for Ocean-Sea Ice Modelling in Australia

--- a/abbreviations.md
+++ b/abbreviations.md
@@ -14,3 +14,4 @@
 *[SU]: Service Units
 *[MED]: Model Evaluation and Diagnostics
 *[ILAMB]: International Land Model Benchmarking
+*[PBS]: Portable Batch System

--- a/abbreviations.md
+++ b/abbreviations.md
@@ -13,3 +13,4 @@
 *[COSIMA]: Consortium for Ocean-Sea Ice Modelling in Australia
 *[SU]: Service Units
 *[MED]: Model Evaluation and Diagnostics
+*[ILAMB]: International Land Model Benchmarking

--- a/abbreviations.md
+++ b/abbreviations.md
@@ -5,3 +5,4 @@
 *[CMIP5]: Coupled Model Intercomparison Project 5
 *[CMIP6]: Coupled Model Intercomparison Project 6
 *[CMIP7]: Coupled Model Intercomparison Project 7
+*[HPC]: High-Performance Computing

--- a/abbreviations.md
+++ b/abbreviations.md
@@ -11,3 +11,4 @@
 *[ARE]: Australian Research Environment
 *[COSIMA]: Consortium for Ocean-Sea Ice Modelling in Australia
 *[SU]: Service Units
+*[MED]: Model Evaluation and Diagnostics

--- a/abbreviations.md
+++ b/abbreviations.md
@@ -6,6 +6,7 @@
 *[CMIP5]: Coupled Model Intercomparison Project 5
 *[CMIP6]: Coupled Model Intercomparison Project 6
 *[CMIP7]: Coupled Model Intercomparison Project 7
+*[AMIP]: Atmospheric Model Intercomparison Project
 *[HPC]: High-Performance Computing
 *[NCI]: (Australian) National Computational Infrastructure
 *[ARE]: Australian Research Environment

--- a/abbreviations.md
+++ b/abbreviations.md
@@ -1,6 +1,7 @@
 *[UKMO]: UK Met Office
-*[ESM]: Earth System Model
 *[MOSRS]: Met Office Science Repository Service
+*[UM]: Unified Model
+*[ESM]: Earth System Model
 *[CMIP]: Coupled Model Intercomparison Project
 *[CMIP5]: Coupled Model Intercomparison Project 5
 *[CMIP6]: Coupled Model Intercomparison Project 6

--- a/abbreviations.md
+++ b/abbreviations.md
@@ -7,3 +7,4 @@
 *[CMIP7]: Coupled Model Intercomparison Project 7
 *[HPC]: High-Performance Computing
 *[NCI]: (Australian) National Computational Infrastructure
+*[ARE]: Australian Research Environment

--- a/abbreviations.md
+++ b/abbreviations.md
@@ -1,2 +1,3 @@
-*[UKMO]: UK MetOffice
+*[UKMO]: UK Met Office
 *[ESM]: Earth System Model
+*[MOSRS]: Met Office Science Repository Service

--- a/abbreviations.md
+++ b/abbreviations.md
@@ -6,3 +6,4 @@
 *[CMIP6]: Coupled Model Intercomparison Project 6
 *[CMIP7]: Coupled Model Intercomparison Project 7
 *[HPC]: High-Performance Computing
+*[NCI]: (Australian) National Computational Infrastructure

--- a/abbreviations.md
+++ b/abbreviations.md
@@ -15,3 +15,4 @@
 *[MED]: Model Evaluation and Diagnostics
 *[ILAMB]: International Land Model Benchmarking
 *[PBS]: Portable Batch System
+*[VDI]: Virtual Desktop Interface

--- a/abbreviations.md
+++ b/abbreviations.md
@@ -1,3 +1,7 @@
 *[UKMO]: UK Met Office
 *[ESM]: Earth System Model
 *[MOSRS]: Met Office Science Repository Service
+*[CMIP]: Coupled Model Intercomparison Project
+*[CMIP5]: Coupled Model Intercomparison Project 5
+*[CMIP6]: Coupled Model Intercomparison Project 6
+*[CMIP7]: Coupled Model Intercomparison Project 7

--- a/abbreviations.md
+++ b/abbreviations.md
@@ -1,0 +1,1 @@
+*[UKMO]: UK MetOffice

--- a/abbreviations.md
+++ b/abbreviations.md
@@ -10,3 +10,4 @@
 *[NCI]: (Australian) National Computational Infrastructure
 *[ARE]: Australian Research Environment
 *[COSIMA]: Consortium for Ocean-Sea Ice Modelling in Australia
+*[SU]: Service Units

--- a/docs/about/faq.md
+++ b/docs/about/faq.md
@@ -51,7 +51,7 @@ Click on the questions to unfold the answers. If your question is not answered, 
 
 ??? question "Where can I find _observational data_ and _model data_?"
     
-    Both observational and model data is hosted by the National Computational Infrastructure (NCI) under different projects. 
+    Both observational and model data is hosted by NCI under different projects. 
 
     Please go to our [**Data**](/model_evaluation/data) section on the ACCESS-Hive Docs to learn how to find and retrieve ACCESS model and observational data.
 

--- a/docs/about/release_list.md
+++ b/docs/about/release_list.md
@@ -45,7 +45,7 @@ In these release notes, make sure you scroll down to the latest post for most re
 |[Model Live Diagnostics](https://forum.access-hive.org.au/t/official-model-live-diagnotics-v1-0-released-today-read-on-to-find-out-more/1647) | Framework to check, monitor, visualise and evaluate model behaviour and progress for models currently running on _Gadi_ |
 |[ACCESS Intake Catalog](https://forum.access-hive.org.au/t/access-nri-intake-catalog-a-way-to-find-load-and-share-data-on-gadi/1659) | Find, load and share ACCESS & ACCESS-related model data on _Gadi_ |
 |[Payu](https://forum.access-hive.org.au/t/payu-a-workflow-manager-for-some-access-models/1098) | Tool used to run a number of ACCESS models on NCI hardware |
-|[um2nc](https://forum.access-hive.org.au/t/um2nc-a-utility-for-converting-unified-model-files-to-netcdf/3968) | Utility for converting Unified Model (UM) data files to netCDF |
+|[um2nc](https://forum.access-hive.org.au/t/um2nc-a-utility-for-converting-unified-model-files-to-netcdf/3968) | Utility for converting UM data files to netCDF |
 |[ACCESS-Vis and Visualisation recipes](https://forum.access-hive.org.au/t/access-visualisation-recipes-1-0-0-is-now-available/3970) | Collection of notebooks to enhance the visualisation of ACCESS climate model data using the `accessvis` python package |
 |[Model tools](https://forum.access-hive.org.au/t/model-tools/4696) | Multiple tools deployed on _Gadi_ to support model tasks, such as FRE-NCtools, mppnccombine-fast, esmf, etc. |
 |[ACCESS Model Scaling](https://forum.access-hive.org.au/t/access-nri-model-scaling-repository-a-collection-of-parallel-scalability-studies/5426) | A collection of Jupyter Notebooks that generate and display scaling data for ACCESS-NRI models |

--- a/docs/about/release_list.md
+++ b/docs/about/release_list.md
@@ -33,7 +33,7 @@ In these release notes, make sure you scroll down to the latest post for most re
 | :--- | :---------- |
 |[ACCESS-ESM1.5](https://forum.access-hive.org.au/t/access-esm1-5-release-information/2352) | A coupled global Earth system model |
 |[ACCESS-OM2](https://forum.access-hive.org.au/t/access-om2-release-information/1602) | Global coupled Ocean-Sea Ice Model developed by COSIMA |
-|[ACCESS-rAM3](https://forum.access-hive.org.au/t/access-ram3-release-information/4308) | An implementation of the UK Met Office (UKMO) regional nesting suite that supports creating regional atmosphere/land configurations in an Australian context |
+|[ACCESS-rAM3](https://forum.access-hive.org.au/t/access-ram3-release-information/4308) | An implementation of the UKMO regional nesting suite that supports creating regional atmosphere/land configurations in an Australian context |
 |[CABLE](https://forum.access-hive.org.au/t/cable-is-now-under-git-and-github/1643) | Land surface model in ACCESS models. Code available on GitHub |
 
 ### Tools

--- a/docs/about/release_list.md
+++ b/docs/about/release_list.md
@@ -40,7 +40,7 @@ In these release notes, make sure you scroll down to the latest post for most re
 | |  |
 | :--- | :---------- |
 |[ESMValTool Workflow](https://forum.access-hive.org.au/t/esmvaltool-workflow-releases/1599) | NCI configuration of ESMValTool developed for evaluations of Earth System Models in CMIP |
-|[iLAMB workflow](https://forum.access-hive.org.au/t/ilamb-workflow-v1-0-launches-today-here-is-what-you-need-to-know/1600) | NCI configurations of International Land Model Benchmarking (ILAMB)|
+|[iLAMB workflow](https://forum.access-hive.org.au/t/ilamb-workflow-v1-0-launches-today-here-is-what-you-need-to-know/1600) | NCI configurations of ILAMB|
 |[Benchcab](https://forum.access-hive.org.au/t/benchcab-python-based-software-for-the-evaluation-of-cable/873/11) | Python-based software for the scientific evaluation of CABLE on NCI |
 |[Model Live Diagnostics](https://forum.access-hive.org.au/t/official-model-live-diagnotics-v1-0-released-today-read-on-to-find-out-more/1647) | Framework to check, monitor, visualise and evaluate model behaviour and progress for models currently running on _Gadi_ |
 |[ACCESS Intake Catalog](https://forum.access-hive.org.au/t/access-nri-intake-catalog-a-way-to-find-load-and-share-data-on-gadi/1659) | Find, load and share ACCESS & ACCESS-related model data on _Gadi_ |

--- a/docs/getting_started/are.md
+++ b/docs/getting_started/are.md
@@ -44,7 +44,7 @@ Hence, there are multiple [PBS directives](https://opus.nci.org.au/display/Help/
     You must be a member of the specified project.
     
     !!! warning
-        The specified project must have allocated _Service Units (SU)_.<br>
+        The specified project must have allocated _SU_.<br>
         For more information, check [how to join relevant NCI projects](/getting_started/set_up_nci_account#join-relevant-nci-projects).
 
 - **Storage**<br>

--- a/docs/getting_started/are.md
+++ b/docs/getting_started/are.md
@@ -3,7 +3,7 @@
 [ARE](https://are.nci.org.au) is a web-based graphical interface for performing your computational research, provided by [NCI](https://nci.org.au).<br>
 ARE gives you access to NCI’s _Gadi_ supercomputer and data collections.
 
-There are multiple applications included in ARE, but the two most used for ACCESS-related activities are [Virtual Desktop (VDI)](#vdi) and [JupyterLab](#jupyterlab).
+There are multiple applications included in ARE, but the two most used for ACCESS-related activities are [VDI](#vdi) and [JupyterLab](#jupyterlab).
 
 ## Prerequisites
 To use ARE, you must have an NCI account and be a member of a project with computing resources (known as Service Units, or SU). For instructions on how to set up an account and join projects, refer to [Set Up your NCI Account](/getting_started/set_up_nci_account).

--- a/docs/getting_started/set_up_nci_account.md
+++ b/docs/getting_started/set_up_nci_account.md
@@ -11,7 +11,7 @@ The steps in this section are aimed at new users who would like to do any of the
 
 ## Create an NCI user account
 
-Most of the data and models you will need are available at the [National Computing Infrastructure (NCI)](https://nci.org.au/about-us/who-we-are).<br>
+Most of the data and models you will need are available at [NCI](https://nci.org.au/about-us/who-we-are).<br>
 To access these, you need an [NCI account](https://opus.nci.org.au/display/Help/How+to+create+an+NCI+user+account). If you do not have one, [sign up here](https://my.nci.org.au/mancini/signup/0").
 
 !!! warning

--- a/docs/getting_started/set_up_nci_account.md
+++ b/docs/getting_started/set_up_nci_account.md
@@ -29,7 +29,7 @@ Each project has an ID (e.g. `xp65`), which is what the term _project_ actually 
 
 If you are interested in datasets and data collections, you can browse the [NCI Data Catalogue](https://geonetwork.nci.org.au/geonetwork/srv/eng/catalog.search#/search) and follow the [NCI Data Catalogue User Guide](https://opus.nci.org.au/display/Help/Data+Catalogue+User+Guide).
 
-To run models on _Gadi_ instead, you need to join a project with computing resources, also called _Service Units (SU)_. The project ID will be provided by your supervisor, research project or institution.
+To run models on _Gadi_ instead, you need to join a project with computing resources, also called _SU_. The project ID will be provided by your supervisor, research project or institution.
 
 To join a project, search for it on [NCI website](https://my.nci.org.au/mancini/project-search) and request membership.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,12 +4,13 @@ hide:
   - toc
 ---
 
-<h1 class="homepage"></h1>
+#
+
 <div class="introduction">
     <div>
         <div>Welcome to ACCESS-Hive Docs!</div>
         <div>
-            Documentation for ACCESS users: getting set up, running models and model evaluation
+            Documentation for <abbr title="Australian Community Climate and Earth System Simulator">ACCESS</abbr> users: getting set up, running models and model evaluation
         </div>
     </div>
     <div>

--- a/docs/js/miscellaneous.js
+++ b/docs/js/miscellaneous.js
@@ -12,22 +12,16 @@ function showNotification(text) {
     }, 2000);
 }
 
-// Set up permalinks (clickable symbol shown when headers are hovered over):
-// - Remove their default behaviour of linking to themselves (treat them as buttons instead of links)
-// - Copy the URL to clipboard when clicking on it
-// - Change symbol to custom one 
 function setUpPermalinks() {
     document.querySelectorAll(".headerlink").forEach(function (link) {
         let permalink = link.href;
-        // Replace the link behaviour by replacing it with a <span> element
-        const span = document.createElement("span");
-        Array.from(link.attributes).forEach(attr => {
-            if (attr.name !== "href") span.setAttribute(attr.name, attr.value);
-        });
-        span.innerHTML = '<i class="fa-solid fa-link fa-xs"></i>'; // Link icon from fontawesome
-        link.replaceWith(span);
-        span.style.cursor = "pointer";
-        span.addEventListener("click", function () {
+        // Change icon to the "Link" icon from fontawesome
+        link.innerHTML = '<i class="fa-solid fa-link fa-xs"></i>';
+        link.style.cursor = "pointer";
+        // Override click behaviour
+        link.addEventListener("click", function (e) {
+            e.preventDefault();
+            e.stopPropagation();
             // Copy permalink to clipboard
             navigator.clipboard.writeText(permalink);
             // Show "Copied to clipboard" notification

--- a/docs/model_evaluation/community_med/community_med_recipes.md
+++ b/docs/model_evaluation/community_med/community_med_recipes.md
@@ -1,7 +1,7 @@
 # Community Model Evaluation and Diagnostics (MED) Recipe Gallery
 
 ???+ danger "Support Level: NOT supported by ACCESS-NRI"
-    Here, we collate lists of useful resources for Model Evaluation and Diagnostics (MED). Contrary to the supported content of our [ACCESS-NRI Model Evaluation pages](/model_evaluation), the information below is not supported by ACCESS-NRI unless stated otherwise.
+    Here, we collate lists of useful resources for MED. Contrary to the supported content of our [ACCESS-NRI Model Evaluation pages](/model_evaluation), the information below is not supported by ACCESS-NRI unless stated otherwise.
 
 While this is a continous effort, this site is intented for a list of model evaluation and diagnostics recipes that are not (yet) ingested but may be interesting for the community:
 

--- a/docs/model_evaluation/community_med/community_med_recipes.md
+++ b/docs/model_evaluation/community_med/community_med_recipes.md
@@ -94,7 +94,6 @@ Please let us know, if we are missing an important tool. Check [How To Contribut
         <a href="https://www.ilamb.org/doc/index.html" target="_blank">Documentation</a> |
         <a href="https://www.ilamb.org/doc/tutorial.html" target="_blank">Tutorial</a> |
         <a href="https://github.com/rubisco-sfa/ILAMB" target="_blank">Source Code</a>
-        <!-- The International Land Model Benchmarking (ILAMB) project is a model-data intercomparison and integration project designed to improve the performance of land models and, in parallel, improve the design of new measurement campaigns to reduce uncertainties associated with key land surface processes. -->
     </div>
 </td>
 </tr>
@@ -115,8 +114,6 @@ Please let us know, if we are missing an important tool. Check [How To Contribut
         <a href="https://www.ilamb.org/doc/index.html" target="_blank">Documentation</a> |
         <a href="https://www.ilamb.org/doc/tutorial.html" target="_blank">Tutorial</a> |
         <a href="https://github.com/rubisco-sfa/ILAMB" target="_blank">Source Code</a>
-        <!-- The International Ocean Model Benchmarking (IOMB) Package is used to evaluate marine biogeochemistry models through comparisons with observations. IOMB provides a variety of in-depth diagnostics of marine biogeochemical model variables on annual and inter-annual time scales. It compares a growing number of variables with site-based, transect, regional, and global observational data sets, and scores model performance based on a combination of bias, RMSE, and seasonal cycle metrics. IOMB is useful for the detailed exploration of ocean biogeochemical model responses and provides an interactive interface designed to enable the user to more rapidly understand the underlying drivers of those responses. IOMB was first applied to evaluate uncertainties associated with marine aerosol precursors [(Ogunro et al., 2018)](https://www.mdpi.com/2073-4433/9/5/184).
-IOMB uses the same code base as the International Land Model Benchmarking (ILAMB) Package, so some of the links above refer to ILAMB instead of IOMB. -->
     </div>
 </td>
 </tr>

--- a/docs/model_evaluation/community_med/community_model_catalogs.md
+++ b/docs/model_evaluation/community_med/community_model_catalogs.md
@@ -83,7 +83,7 @@ Please let us know, if we are missing an important catalogue. Check [How To Cont
 </td>
 <td width="75%">
     <div align='center' width="100%" >
-        The Intake-Ilamb catalog provides an yaml-style intake catalogue of the reference data used for ESM model benchmarking in the International Land Model Benchmarking <a href="https://www.ilamb.org/" target="_blank">(ILAMB)</a> effort.
+        The Intake-Ilamb catalog provides a yaml-style intake catalogue of the reference data used for ESM model benchmarking in <a href="https://www.ilamb.org/" target="_blank">ILAMB</a>.
     </div>
 </td>
 </tr>

--- a/docs/model_evaluation/community_med/community_model_catalogs.md
+++ b/docs/model_evaluation/community_med/community_model_catalogs.md
@@ -1,7 +1,7 @@
 # Community Model Data Catalogues
 
 ???+ danger "Support Level: NOT supported by ACCESS-NRI"
-    Here, we collate lists of useful resources for Model Evaluation and Diagnostics (MED). Contrary to the supported content of our [ACCESS-NRI Model Evaluation pages](/model_evaluation), the information below is not supported by ACCESS-NRI unless stated otherwise.
+    Here, we collate lists of useful resources for MED. Contrary to the supported content of our [ACCESS-NRI Model Evaluation pages](/model_evaluation), the information below is not supported by ACCESS-NRI unless stated otherwise.
 
 
 Please let us know, if we are missing an important catalogue. Check [How To Contribute](/about/contribute) to get in touch.

--- a/docs/model_evaluation/community_med/community_observational_catalogs.md
+++ b/docs/model_evaluation/community_med/community_observational_catalogs.md
@@ -1,7 +1,7 @@
 # Community Observational Data Catalogues
 
 ???+ danger "Support Level: NOT supported by ACCESS-NRI"
-    Here, we collate lists of useful resources for Model Evaluation and Diagnostics (MED). Contrary to the supported content of our [ACCESS-NRI Model Evaluation pages](/model_evaluation), the information below is not supported by ACCESS-NRI unless stated otherwise.
+    Here, we collate lists of useful resources for MED. Contrary to the supported content of our [ACCESS-NRI Model Evaluation pages](/model_evaluation), the information below is not supported by ACCESS-NRI unless stated otherwise.
 
 Please let us know if we are missing an important catalogue. Check [How To Contribute](/about/contribute) to get in touch.
 

--- a/docs/model_evaluation/data/finding/access_nri_intake.md
+++ b/docs/model_evaluation/data/finding/access_nri_intake.md
@@ -16,7 +16,7 @@ The ACCESS-NRI Intake Catalogue also enables users to directly load the desired 
     The catalogue table files are in the `conda/analysis3` environment in _xp65_. Join the [xp65](https://my.nci.org.au/mancini/project/xp65/join) project by requesting membership on its NCI project page.
 - **Join any projects that have data you're interested in.**
 
-The easiest way to use the catalogue is through _JupyterLab_ on the [Australian Research Environment(ARE)](/getting_started/are/#jupyterlab).
+The easiest way to use the catalogue is through _JupyterLab_ on [ARE](/getting_started/are/#jupyterlab).
 
 
 ## Example: using the ACCESS-NRI Intake Catalogue to find, load and plot data with Python

--- a/docs/model_evaluation/data/finding/index.md
+++ b/docs/model_evaluation/data/finding/index.md
@@ -32,7 +32,7 @@ a few exceptions noted below.
 
 
 ## NCI Data Catalogue
-The **[NCI Data Catalogue](https://geonetwork.nci.org.au/geonetwork/srv/eng/catalog.search#/home)** is a publicly accessible web-based catalogue. It is the authoritative source for published and curated ACCESS datasets hosted at the National Computational Infrastructure (NCI).
+The **[NCI Data Catalogue](https://geonetwork.nci.org.au/geonetwork/srv/eng/catalog.search#/home)** is a publicly accessible web-based catalogue. It is the authoritative source for published and curated ACCESS datasets hosted at NCI.
 
 The catalogue allows you to search and browse for datasets and includes:
 

--- a/docs/model_evaluation/data/observations.md
+++ b/docs/model_evaluation/data/observations.md
@@ -4,7 +4,7 @@ NCI not only hosts numerous datasets for climate research, it also manages and o
 
 Some examples of NCI data collections include:
 - [Earth Systems Grid Federation](https://esgf.llnl.gov/) data hosted at the [NCI ESGF Node](https://esgf.nci.org.au/projects/esgf-nci/).
-- [ECMWF atmospheric reanalyses (ERA5)](https://www.ecmwf.int/en/forecasts/dataset/ecmwf-reanalysis-v5) data. For more information, refer to the [NCI ERA5 Community Page](https://opus.nci.org.au/display/ERA5/ERA5+Community+Home).
+- [ECMWF atmospheric reanalyses (ERA5)](https://cds.climate.copernicus.eu/datasets/reanalysis-era5-single-levels?tab=overview) data. For more information, refer to the [NCI ERA5 Community Page](https://opus.nci.org.au/display/ERA5/ERA5+Community+Home).
 - [Sentinel Australasia Regional Access (SARA)](https://copernicus.nci.org.au/sara.client/#/home) data obtained from the European Space Agency's multi-petabyte Sentinel satellite.
 
 NCI also has a [user guide](https://opus.nci.org.au/display/NDP/NCI+Data+Catalogue) for finding, accessing and citing data.

--- a/docs/model_evaluation/evaluation_on_gadi/cosima.md
+++ b/docs/model_evaluation/evaluation_on_gadi/cosima.md
@@ -12,7 +12,7 @@ The <i>COSIMA Cookbook</i> framework focuses on the <a href="/models/access_mode
 
 ## Getting Started
 
-The easiest way to use the _COSIMA Cookbook_ is through the [Australian Research Environment (ARE)](https://are.nci.org.au)" on _Gadi_.<br>
+The easiest way to use the _COSIMA Cookbook_ is through [ARE](https://are.nci.org.au)" on _Gadi_.<br>
 To be able to access _Gadi_ you need to have an NCI account. For more information, check how to [Set Up your NCI Account](/getting_started/set_up_nci_account).
 
 To use the <i>COSIMA Cookbook</i> in the `conda/analysis3` environment of *xp65*, you need to <a href="https://my.nci.org.au/mancini/project/xp65" target="_blank">join NCI project *xp65*</a>.

--- a/docs/model_evaluation/evaluation_on_gadi/ilamb_workflow.md
+++ b/docs/model_evaluation/evaluation_on_gadi/ilamb_workflow.md
@@ -68,7 +68,7 @@ To learn more about how to adjust the <i>ILAMB</i> setup, refer to the official 
 
 ## Example: CMIP6 comparisons and ACCESS ESM1.5 benchmarking
 
-ACCESS-NRI is maintaining a collection of benchmark comparisons for the ACCESS community, such as that with Coupled Model Intercomparison Project (CMIP) data, see in the <a href="https://ilamb-workflow.readthedocs.io/en/latest/source/ILAMB.html#ilamb-cmip-confrontations-maintained-by-access-nri" target="_blank">workflow documentation.</a>
+ACCESS-NRI is maintaining a collection of benchmark comparisons for the ACCESS community, such as that with CMIP data, see in the <a href="https://ilamb-workflow.readthedocs.io/en/latest/source/ILAMB.html#ilamb-cmip-confrontations-maintained-by-access-nri" target="_blank">workflow documentation.</a>
 
 
 In the following example, the supported <a href="/models/access_models/access-esm#access-esm1.5" target="_blank">ACCESS-ESM1.5</a> is compared with two other ESM models:

--- a/docs/model_evaluation/evaluation_on_gadi/ilamb_workflow.md
+++ b/docs/model_evaluation/evaluation_on_gadi/ilamb_workflow.md
@@ -71,7 +71,7 @@ To learn more about how to adjust the <i>ILAMB</i> setup, refer to the official 
 ACCESS-NRI is maintaining a collection of benchmark comparisons for the ACCESS community, such as that with Coupled Model Intercomparison Project (CMIP) data, see in the <a href="https://ilamb-workflow.readthedocs.io/en/latest/source/ILAMB.html#ilamb-cmip-confrontations-maintained-by-access-nri" target="_blank">workflow documentation.</a>
 
 
-In the following example, the supported ACCESS Earth System Model (ESM) <a href="/models/access_models/access-esm#access-esm1.5" target="_blank">ACCESS-ESM1.5</a> is compared with two other ESM models:
+In the following example, the supported <a href="/models/access_models/access-esm#access-esm1.5" target="_blank">ACCESS-ESM1.5</a> is compared with two other ESM models:
 
 - <a href="https://gmd.copernicus.org/articles/13/977/2020/" target="_blank">BCC ESM1 (Beijing Climate Center Earth System Model version 1)</a>
 - <a href="https://gmd.copernicus.org/articles/12/4823/2019/gmd-12-4823-2019.html" target="_blank">CanESM5 (Canadian Earth System Model version 5)</a>

--- a/docs/model_evaluation/index.md
+++ b/docs/model_evaluation/index.md
@@ -1,7 +1,7 @@
 #  Data and Model Evaluation 
 
 
-In this section you will find some collated information on data in the context of climate modelling which is important for model evaluation. Then there is also a collation of model evaluation tools available on *Gadi*. If you are new to using the Gadi supercomputer, visit the [Set Up your NCI Account](/getting_started/set_up_nci_account) section for instructions on how to get an account, log in, and get set up to access climate data on Gadi. ACCESS-NRI supports and maintains the [conda/analysis3 _Python_ environment](/getting_started/environments) which contains most of the evaluation and data tools described.
+In this section you will find some collated information on data in the context of climate modelling which is important for model evaluation. Then there is also a collation of model evaluation tools available on *Gadi*. If you are new to using the Gadi supercomputer, visit the [Set Up your NCI Account](/getting_started/set_up_nci_account) section for instructions on how to get an account, log in, and get set up to access climate data on Gadi. ACCESS-NRI supports and maintains the [conda/analysis3 _Python_ environment](/getting_started/environments){: data-preview } which contains most of the evaluation and data tools described.
 <!--## Prerequisites
 
 If you are new to MED and are wondering [*"What is Model Evaluation and Diagnostics about?"*](./model_evaluation_getting_started/index.md), we recommend you read our [Getting Started with MED page](./model_evaluation_getting_started/index.md): -->

--- a/docs/models/access_models/access-cm.md
+++ b/docs/models/access_models/access-cm.md
@@ -12,7 +12,7 @@ It produces physical climate simulations.
 !!! danger
     ACCESS-NRI does not maintain an official {{model}} release, but we continue to support the community in using this model where possible.
 
-[ACCESS-CM2](https://www.publish.csiro.au/es/ES19040) [@Bi2020] was initially developed by [CSIRO](https://www.csiro.au/) and is one of Australia’s contributions to the World Climate Research Programme’s [Coupled Model Intercomparison Project Phase 6 (CMIP6)](https://wcrp-cmip.org/cmip6/).
+[ACCESS-CM2](https://www.publish.csiro.au/es/ES19040) [@Bi2020] was initially developed by [CSIRO](https://www.csiro.au/) and is one of Australia’s contributions to the World Climate Research Programme’s [CMIP6](https://wcrp-cmip.org/cmip6/).
 
 ### Model components
 - **Atmosphere**: [UM10.6](/models/model_components/atmosphere#unified-model-um), GA7.1 science configuration.<br>

--- a/docs/models/access_models/access-esm.md
+++ b/docs/models/access_models/access-esm.md
@@ -7,7 +7,7 @@ This means it can simulate both the physical climate and global biogeochemical c
 
 ## ACCESS-ESM1.5
 
-[ACCESS-ESM1.5](https://www.publish.csiro.au/es/ES19035) [@Ziehn2020] is a fully-coupled climate model with land and ocean carbon cycle components. ACCESS-ESM1.5 was developed primarily to enable Australia to participate in the [Coupled Model Intercomparison Project Phase 6 (CMIP6)](https://wcrp-cmip.org/cmip6/) with an ESM version.
+[ACCESS-ESM1.5](https://www.publish.csiro.au/es/ES19035) [@Ziehn2020] is a fully-coupled climate model with land and ocean carbon cycle components. ACCESS-ESM1.5 was developed primarily to enable Australia to participate in the [CMIP6](https://wcrp-cmip.org/cmip6/) with an ESM version.
 
 ACCESS-NRI has released [ACCESS-ESM1.5 configurations](https://github.com/ACCESS-NRI/access-esm1.5-configs) as an adaptation of those originally developed by [CSIRO](https://www.csiro.au/en/research/environmental-impacts/climate-change/climate-science-centre) and [CLEX CMS](https://github.com/coecms/access-esm).
 

--- a/docs/models/access_models/access-esm.md
+++ b/docs/models/access_models/access-esm.md
@@ -7,7 +7,7 @@ This means it can simulate both the physical climate and global biogeochemical c
 
 ## ACCESS-ESM1.5
 
-[ACCESS-ESM1.5](https://www.publish.csiro.au/es/ES19035) [@Ziehn2020] is a fully-coupled climate model with land and ocean carbon cycle components. ACCESS-ESM1.5 was developed primarily to enable Australia to participate in the [Coupled Model Intercomparison Project Phase 6 (CMIP6)](https://wcrp-cmip.org/cmip6/) with an Earth System Model (ESM) version.
+[ACCESS-ESM1.5](https://www.publish.csiro.au/es/ES19035) [@Ziehn2020] is a fully-coupled climate model with land and ocean carbon cycle components. ACCESS-ESM1.5 was developed primarily to enable Australia to participate in the [Coupled Model Intercomparison Project Phase 6 (CMIP6)](https://wcrp-cmip.org/cmip6/) with an ESM version.
 
 ACCESS-NRI has released [ACCESS-ESM1.5 configurations](https://github.com/ACCESS-NRI/access-esm1.5-configs) as an adaptation of those originally developed by [CSIRO](https://www.csiro.au/en/research/environmental-impacts/climate-change/climate-science-centre) and [CLEX CMS](https://github.com/coecms/access-esm).
 

--- a/docs/models/access_models/access-om.md
+++ b/docs/models/access_models/access-om.md
@@ -13,7 +13,7 @@ The atmospheric fields that drive the model are provided by a data source, usual
 
 [![Config docs](/assets/ACCESS_icon_HIVE.png){: class="icon-before-text"} {{ model }} configs docs]({{om3_configs_docs}}){: class="text-card"}
 
-{{ model }} is a suite of coupled ocean-sea ice models developed by ACCESS-NRI and the [Consortium for Ocean-Sea Ice Modelling in Australia (COSIMA)][cosima].
+{{ model }} is a suite of coupled ocean-sea ice models developed by ACCESS-NRI and [COSIMA][cosima].
 
 ACCESS-NRI has released [{{ model }} configurations](https://github.com/ACCESS-NRI/access-om3-configs).
 
@@ -47,7 +47,7 @@ Each configuration also has an optional biogeochemical (BGC) configuration that 
 {% set model = "ACCESS-OM2" %}
 ## {{ model }}
 
-[{{ model }}](https://gmd.copernicus.org/articles/13/401/2020/) [@Kiss2020] [@ACCESS-OM2-report] [@Solodoch2022] [@Hayashida2023] [@Menviel2023] is a suite of coupled ocean-sea ice models originally developed by the [Consortium for Ocean-Sea Ice Modelling in Australia (COSIMA)][cosima].<br>
+[{{ model }}](https://gmd.copernicus.org/articles/13/401/2020/) [@Kiss2020] [@ACCESS-OM2-report] [@Solodoch2022] [@Hayashida2023] [@Menviel2023] is a suite of coupled ocean-sea ice models originally developed by [COSIMA][cosima].<br>
 
 ACCESS-NRI has released [{{ model }} configurations](https://github.com/ACCESS-NRI/access-om2-configs) as an adaptation of those originally developed by COSIMA.
 

--- a/docs/models/access_models/access-ram.md
+++ b/docs/models/access_models/access-ram.md
@@ -1,6 +1,7 @@
 {% set ram3_configs_docs = "https://access-ram3-configs.access-hive.org.au" %}
 {% set model = "ACCESS-rAM3" %}
 [run_access-ram]: /models/run_a_model/run_access-ram3
+[era5]: https://cds.climate.copernicus.eu/datasets/reanalysis-era5-single-levels?tab=overview
 
 # ACCESS-rAM 
 
@@ -23,7 +24,7 @@ Since the regional forecasting is performed separately for each nested region an
 
 [![Config docs](/assets/ACCESS_icon_HIVE.png){: class="icon-before-text"} {{ model }} configs docs]({{ram3_configs_docs}}){: class="text-card"}
 
-Similar to the UKMO Regional Nesting Suite, {{ model }} is configured to derive its initial and lateral boundary conditions from the [ECMWF Reanalysis v5 (ERA5)](https://www.ecmwf.int/en/forecasts/dataset/ecmwf-reanalysis-v5) dataset.<br>
+Similar to the UKMO Regional Nesting Suite, {{ model }} is configured to derive its initial and lateral boundary conditions from the [ECMWF Reanalysis v5 (ERA5)][era5] dataset.<br>
 However, for its land-surface initial conditions, {{ model }} offers flexibility by allowing the use of alternative datasets.
 
 Information about the amount of NCI resources (such as SU and storage) used by a typical ACCESS-rAM3 experiment run are available on the [ACCESS-Hive Forum release notes page](https://forum.access-hive.org.au/t/access-ram3-release-information/4308).
@@ -32,11 +33,11 @@ Information about the amount of NCI resources (such as SU and storage) used by a
 
 #### Land-surface initial conditions source options
 - [ERA5-Land](https://www.ecmwf.int/en/era5-land)
-- [ERA5](https://www.ecmwf.int/en/forecasts/dataset/ecmwf-reanalysis-v5)
+- [ERA5][era5]
 - [BARRA-R2](https://www.bom.gov.au/research/publications/researchreports/BRR-067.pdf) (default)
 
 #### Sea surface temperature (SST) and sea-ice initial and boundary conditions source options {: #sst .no-toc }
-- [ERA5](https://www.ecmwf.int/en/forecasts/dataset/ecmwf-reanalysis-v5) - 0.25 degree resolution
+- [ERA5][era5] - 0.25 degree resolution
 - [OSTIA](https://data.marine.copernicus.eu/product/SST_GLO_SST_L4_NRT_OBSERVATIONS_010_001/description) - daily 0.05 degree resolution
 
 ### Nesting configuration

--- a/docs/models/access_models/access-ram.md
+++ b/docs/models/access_models/access-ram.md
@@ -26,7 +26,7 @@ Since the regional forecasting is performed separately for each nested region an
 Similar to the UKMO Regional Nesting Suite, {{ model }} is configured to derive its initial and lateral boundary conditions from the [ECMWF Reanalysis v5 (ERA5)](https://www.ecmwf.int/en/forecasts/dataset/ecmwf-reanalysis-v5) dataset.<br>
 However, for its land-surface initial conditions, {{ model }} offers flexibility by allowing the use of alternative datasets.
 
-Information about the amount of NCI resources (such as Service Units (SU) and storage) used by a typical ACCESS-rAM3 experiment run are available on the [ACCESS-Hive Forum release notes page](https://forum.access-hive.org.au/t/access-ram3-release-information/4308).
+Information about the amount of NCI resources (such as SU and storage) used by a typical ACCESS-rAM3 experiment run are available on the [ACCESS-Hive Forum release notes page](https://forum.access-hive.org.au/t/access-ram3-release-information/4308).
 
 ### Initial and boundary conditions
 

--- a/docs/models/access_models/access-ram.md
+++ b/docs/models/access_models/access-ram.md
@@ -6,7 +6,7 @@
 
 ![ACCESS RAM model](/assets/model-config-logos/configurations-without-titles/access-ram.png){: class="img-contain white-background round-edges with-padding intro-img" loading="lazy"}
 
-The ACCESS Regional Atmosphere Model (ACCESS-rAM) is an implementation of the [UK Met Office (UKMO)](https://www.metoffice.gov.uk/) Regional Nesting Suite, comprising [atmosphere](/models/model_components/atmosphere) and [land](/models/model_components/land) components.<br>
+The ACCESS Regional Atmosphere Model (ACCESS-rAM) is an implementation of the [UKMO](https://www.metoffice.gov.uk/) Regional Nesting Suite, comprising [atmosphere](/models/model_components/atmosphere) and [land](/models/model_components/land) components.<br>
 Unlike the UKMO Regional Nesting Suite that relies on operational land-surface initial conditions, ACCESS-rAM derives its initial conditions from alternative sources, enhancing its capability for high-resolution regional atmosphere modelling on [Gadi](https://opus.nci.org.au/display/Help/0.+Welcome+to+Gadi#id-0.WelcometoGadi-Overview).
 
 ACCESS-rAM requires both initial conditions and lateral boundary (_driving_) conditions. It also supports multiple [_nesting_](#nesting) configurations, automatically providing their necessary initial and lateral boundary conditions.

--- a/docs/models/access_models/index.md
+++ b/docs/models/access_models/index.md
@@ -1,7 +1,7 @@
 # ACCESS Models
 
 ACCESS models are computer programs that represent key components of the Earth's climate system, including the atmosphere, oceans, land surface, and sea ice. These models use complex mathematical equations to simulate past, present, and future weather and climate conditions, as well as idealised scenarios. Different ACCESS models are configured with varying combinations of Earth system components to address specific research needs.<br>
-Developed in collaboration with international climate modeling institutions, these models are optimised for Australia’s high-performance computing (HPC) systems and tailored for Australian researchers.
+Developed in collaboration with international climate modeling institutions, these models are optimised for Australia’s HPC systems and tailored for Australian researchers.
 
 Below is a list of ACCESS models supported by ACCESS-NRI.
 

--- a/docs/models/build_a_model/build_source_code.md
+++ b/docs/models/build_a_model/build_source_code.md
@@ -20,7 +20,7 @@ The following instructions outline how to build an ACCESS model and its dependen
 These instructions may suit more advanced users who are making iterative changes and need to repeatedly modify the source code, recompile it and run tests. This option also requires setting up a Spack build environment.<br>
 If you want to modify and build a model, while maintaining a clear record of your changes and being able to share the modified builds with others, refer to [Create Prereleases and Releases for an ACCESS Model](/models/build_a_model/create_a_prerelease) instead.
 
-The build workflow described in this page is specifically designed to run on the [National Computating Infrastructure (NCI)](https://nci.org.au/about-us/who-we-are) supercomputer [_Gadi_][gadi].
+The build workflow described in this page is specifically designed to run on [NCI](https://nci.org.au/about-us/who-we-are)'s supercomputer [_Gadi_][gadi].
 
 As an example, in the following instructions we will show how to modify [MOM5 component] for [ACCESS-ESM1.5][esm1.5 config] and re-compile the relevant ACCESS-ESM1.5 dependencies. All other components and packages (i.e., dependencies) of the official [ACCESS-ESM1.5 release]({{esm1_5_build_config}}) will remain unchanged.
 

--- a/docs/models/run_a_model/index.md
+++ b/docs/models/run_a_model/index.md
@@ -1,5 +1,5 @@
 # Run a Model
-These instructions are for running the ACCESS models on the Australian National Computational Infrastructure (NCI). If you do not yet have an NCI account, please [Set Up your NCI Account](/getting_started/set_up_nci_account).
+These instructions are for running the ACCESS models on NCI. If you do not yet have an NCI account, please [Set Up your NCI Account](/getting_started/set_up_nci_account).
 
 If you are unsure which ACCESS model is the best fit for your application, you can read more about each model on the [ACCESS Models page](/models/access_models).
 

--- a/docs/models/run_a_model/rose_cylc.md
+++ b/docs/models/run_a_model/rose_cylc.md
@@ -9,7 +9,7 @@
 The _Rose/Cylc_ workflow management tool consists of two components:
 
 * The [_Cylc_](https://niwa.co.nz/environmental-information/cylc-suite-engine) (pronounced ‘silk’) task engine, developed by the New Zealand National Institute of Water and Atmospheric Research (NIWA). Cylc is a workflow manager that automatically executes tasks according to the model's configuration. It also monitors all tasks, reporting any errors that may occur.
-* The [_Rose_](https://www.metoffice.gov.uk/research/approach/modelling-systems/rose) framework developed by the UK Met Office (UKMO) which configures tasks for the _Cylc_ engine. Rose is a toolkit that can be used to view, edit and run some of the [ACCESS models](/models/access_models).
+* The [_Rose_](https://www.metoffice.gov.uk/research/approach/modelling-systems/rose) framework developed by the UKMO which configures tasks for the _Cylc_ engine. Rose is a toolkit that can be used to view, edit and run some of the [ACCESS models](/models/access_models).
 
 A set of tasks configured by _Rose_ to run with the _Cylc7_ engine is called a _suite_. Every _suite_ has a unique identifier called `suite-ID` in the form `u-LLNNN`, where `L` is a letter and `N` is a number (e.g., u-ab123).
 

--- a/docs/models/run_a_model/rose_cylc.md
+++ b/docs/models/run_a_model/rose_cylc.md
@@ -63,7 +63,7 @@ Go to the [ARE VDI](https://are.nci.org.au/pun/sys/dashboard/batch_connect/sys/d
 - **Compute Size** &rarr; `tiny` (1 CPU)<br>
 
 - **Project** &rarr; a project of which you are a member.<br>
-    The project must have allocated [_Service Units (SU)_](https://opus.nci.org.au/spaces/Help/pages/236881132/Allocations...). By default, this will be set to your default project `$PROJECT`.
+    The project must have allocated [_SU_](https://opus.nci.org.au/spaces/Help/pages/236881132/Allocations...). By default, this will be set to your default project `$PROJECT`.
 
 - **Storage** &rarr; `gdata/hr22+scratch/$PROJECT` (minimum)<br>
     The storage folders listed above are the minimum required to run _Rose/Cylc_.

--- a/docs/models/run_a_model/rose_cylc.md
+++ b/docs/models/run_a_model/rose_cylc.md
@@ -20,7 +20,7 @@ A set of tasks configured by _Rose_ to run with the _Cylc7_ engine is called a _
     Before running an ACCESS model, you need to [Set Up your NCI Account](/getting_started/set_up_nci_account).
 
 - **MOSRS account**<br>
-    The [Met Office Science Repository Service (MOSRS)](https://code.metoffice.gov.uk) is a server run by the UKMO to support collaborative development with other partners organisations. MOSRS contains the source code for some ACCESS model components and configurations, and a MOSRS account is a license requirement to run some ACCESS configurations.<br>
+    [MOSRS](https://code.metoffice.gov.uk) is a server run by the UKMO to support collaborative development with other partners organisations. MOSRS contains the source code for some ACCESS model components and configurations, and a MOSRS account is a license requirement to run some ACCESS configurations.<br>
     To apply for a MOSRS account, please contact your [local institutional sponsor](https://opus.nci.org.au/display/DAE/Prerequisites).
     {: #mosrs-account}
 

--- a/docs/models/run_a_model/run_access-cm2.md
+++ b/docs/models/run_a_model/run_access-cm2.md
@@ -18,7 +18,7 @@
     Before running {{ model }}, you need to [Set Up your NCI Account](/getting_started/set_up_nci_account).
 
 - **_MOSRS_ account**<br>
-    The [Met Office Science Repository Service (MOSRS)](https://code.metoffice.gov.uk) is a server run by the UKMO to support collaborative development with other partners organisations. MOSRS contains the source code and configurations for some model components in {{ model }} (e.g., the [UM](/models/model_components/atmosphere/#unified-model-um)).<br>
+    [MOSRS](https://code.metoffice.gov.uk) is a server run by the UKMO to support collaborative development with other partners organisations. MOSRS contains the source code and configurations for some model components in {{ model }} (e.g., the [UM](/models/model_components/atmosphere/#unified-model-um)).<br>
     To apply for a _MOSRS_ account, please contact your [local institutional sponsor](https://opus.nci.org.au/display/DAE/Prerequisites).
     {: #mosrs-account}
 

--- a/docs/models/run_a_model/run_access-cm2.md
+++ b/docs/models/run_a_model/run_access-cm2.md
@@ -62,7 +62,7 @@ Go to the [ARE VDI](https://are.nci.org.au/pun/sys/dashboard/batch_connect/sys/d
     As mentioned above, the ARE VDI session is only needed for setup and startup tasks, which can be easily accomplished with 1 CPU.
 
 - **Project** &rarr; a project of which you are a member.<br>
-    The project must have allocated _Service Units (SU)_ to run your simulation. Usually, but not always, this corresponds to your `$PROJECT`.<br>
+    The project must have allocated _SU_ to run your simulation. Usually, but not always, this corresponds to your `$PROJECT`.<br>
     For more information, refer to how to [Join relevant NCI projects](/getting_started/set_up_nci_account#join-relevant-nci-projects).
 
 - **Storage** &rarr; `gdata/access+gdata/xp65+gdata/hr22+gdata/ki32` (minimum)<br>
@@ -98,7 +98,7 @@ persistent-sessions start -p <project> <name>
 ```
 
 !!! tip
-    While the project assigned to a persistent session does not have to be the same as the project used to run the {{ model }} configuration, it does need to have allocated _Service Units (SU)_.<br>
+    While the project assigned to a persistent session does not have to be the same as the project used to run the {{ model }} configuration, it does need to have allocated _SU_.<br>
     For more information, check how to [Join relevant NCI projects](/getting_started/set_up_nci_account#join-relevant-nci-projects).
 
 <terminal-window data="input">
@@ -294,7 +294,7 @@ For example, to run an {{ model }} suite under the `tm70` project (ACCESS-NRI), 
 ![Rose change project example](/assets/run_access_cm/rose_change_project_are.gif){: class="example-img" loading="lazy"}
 
 !!! warning
-    To run {{ model }}, you need to be a member of a project with allocated _Service Units (SU)_. For more information, check how to [Join relevant NCI projects](/getting_started/set_up_nci_account#join-relevant-nci-projects).
+    To run {{ model }}, you need to be a member of a project with allocated _SU_. For more information, check how to [Join relevant NCI projects](/getting_started/set_up_nci_account#join-relevant-nci-projects).
 
 ### Change run length and cycling frequency
 

--- a/docs/models/run_a_model/run_access-cm2.md
+++ b/docs/models/run_a_model/run_access-cm2.md
@@ -18,7 +18,7 @@
     Before running {{ model }}, you need to [Set Up your NCI Account](/getting_started/set_up_nci_account).
 
 - **_MOSRS_ account**<br>
-    The [Met Office Science Repository Service (MOSRS)](https://code.metoffice.gov.uk) is a server run by the UK Met Office (UKMO) to support collaborative development with other partners organisations. MOSRS contains the source code and configurations for some model components in {{ model }} (e.g., the [UM](/models/model_components/atmosphere/#unified-model-um)).<br>
+    The [Met Office Science Repository Service (MOSRS)](https://code.metoffice.gov.uk) is a server run by the UKMO to support collaborative development with other partners organisations. MOSRS contains the source code and configurations for some model components in {{ model }} (e.g., the [UM](/models/model_components/atmosphere/#unified-model-um)).<br>
     To apply for a _MOSRS_ account, please contact your [local institutional sponsor](https://opus.nci.org.au/display/DAE/Prerequisites).
     {: #mosrs-account}
 

--- a/docs/models/run_a_model/run_access-cm2.md
+++ b/docs/models/run_a_model/run_access-cm2.md
@@ -42,7 +42,7 @@
     For more information on joining specific NCI projects, refer to [How to connect to a project](https://opus.nci.org.au/display/Help/How+to+connect+to+a+project).
 
 - **Connection to an ARE VDI Desktop (optional)**<br>
-    To run {{ model }}, start an [Australian Research Environment (ARE) VDI Desktop](https://are.nci.org.au/pun/sys/dashboard/batch_connect/sys/desktop_vnc/ncigadi/session_contexts/new) session.<br>
+    To run {{ model }}, start an [ARE VDI Desktop](https://are.nci.org.au/pun/sys/dashboard/batch_connect/sys/desktop_vnc/ncigadi/session_contexts/new) session.<br>
     If you are not familiar with ARE, check out the [Getting Started on ARE](/getting_started/are) section.
 
 ## Set up an ARE VDI Desktop (optional)

--- a/docs/models/run_a_model/run_access-esm.md
+++ b/docs/models/run_a_model/run_access-esm.md
@@ -19,7 +19,7 @@
 
 {{ model }} is a fully-coupled global climate model, combining  atmosphere, land, ocean, sea ice, ocean biogeochemistry and land biogeochemistry components. A description of the model and its components is available in the [{{ model }} overview][model configurations].
 
-The instructions below outline how to run {{ model }} using ACCESS-NRI's software deployment pipeline, specifically designed to run on the [National Computational Infrastructure (NCI)](https://nci.org.au/about-us/who-we-are) supercomputer [_Gadi_][gadi].
+The instructions below outline how to run {{ model }} using ACCESS-NRI's software deployment pipeline, specifically designed to run on [NCI](https://nci.org.au/about-us/who-we-are)'s supercomputer [_Gadi_][gadi].
 
 If you are unsure whether {{ model }} is the right choice for your experiment, take a look at the overview of [ACCESS Models](/models).
 

--- a/docs/models/run_a_model/run_access-esm.md
+++ b/docs/models/run_a_model/run_access-esm.md
@@ -34,7 +34,7 @@ All {{model}} configurations are open source, licensed under [CC BY 4.0](https:/
     Before running {{ model }}, you need to [Set Up your NCI Account](/getting_started/set_up_nci_account).
 
 - **_MOSRS_ account**<br>
-    The [Met Office Science Repository Service (MOSRS)](https://code.metoffice.gov.uk) is a server run by the UK Met Office (UKMO) to support collaborative development with other partners organisations. MOSRS contains the source code and configurations for some model components in {{ model }} (e.g., the [UM](/models/model_components/atmosphere/#unified-model-um)).<br>
+    The [Met Office Science Repository Service (MOSRS)](https://code.metoffice.gov.uk) is a server run by the UKMO to support collaborative development with other partners organisations. MOSRS contains the source code and configurations for some model components in {{ model }} (e.g., the [UM](/models/model_components/atmosphere/#unified-model-um)).<br>
     To apply for a _MOSRS_ account, please contact your [local institutional sponsor](https://opus.nci.org.au/display/DAE/Prerequisites).
     {: #mosrs-account}
 

--- a/docs/models/run_a_model/run_access-esm.md
+++ b/docs/models/run_a_model/run_access-esm.md
@@ -34,7 +34,7 @@ All {{model}} configurations are open source, licensed under [CC BY 4.0](https:/
     Before running {{ model }}, you need to [Set Up your NCI Account](/getting_started/set_up_nci_account).
 
 - **_MOSRS_ account**<br>
-    The [Met Office Science Repository Service (MOSRS)](https://code.metoffice.gov.uk) is a server run by the UKMO to support collaborative development with other partners organisations. MOSRS contains the source code and configurations for some model components in {{ model }} (e.g., the [UM](/models/model_components/atmosphere/#unified-model-um)).<br>
+    [MOSRS](https://code.metoffice.gov.uk) is a server run by the UKMO to support collaborative development with other partners organisations. MOSRS contains the source code and configurations for some model components in {{ model }} (e.g., the [UM](/models/model_components/atmosphere/#unified-model-um)).<br>
     To apply for a _MOSRS_ account, please contact your [local institutional sponsor](https://opus.nci.org.au/display/DAE/Prerequisites).
     {: #mosrs-account}
 

--- a/docs/models/run_a_model/run_access-esm.md
+++ b/docs/models/run_a_model/run_access-esm.md
@@ -451,7 +451,7 @@ project: lg87
     If more than one project is used to run an {{ model }} configuration the `shortpath` option also needs to be uncommented and the path to the desired `/scratch/PROJECT_CODE` directory added.<br>
     This ensures the same `/scratch` location is used for the _laboratory_, regardless of which project is used to run the experiment.
     <br><br>
-    To run {{ model }}, you need to be a member of a project with allocated _Service Units (SU)_. For more information, check [how to join relevant NCI projects](/getting_started/set_up_nci_account#join-relevant-nci-projects).
+    To run {{ model }}, you need to be a member of a project with allocated _SU_. For more information, check [how to join relevant NCI projects](/getting_started/set_up_nci_account#join-relevant-nci-projects).
 
 ### Syncing output data
 

--- a/docs/models/run_a_model/run_access-om2.md
+++ b/docs/models/run_a_model/run_access-om2.md
@@ -33,7 +33,7 @@ All {{model}} configurations are open source, licensed under [CC BY 4.0](https:/
 ## Prerequisites
 
 !!! warning
-    To run {{ model }}, you need to be a member of a project with allocated _Service Units (SU)_. For more information, check [how to join relevant NCI projects](/getting_started/set_up_nci_account#join-relevant-nci-projects).
+    To run {{ model }}, you need to be a member of a project with allocated _SU_. For more information, check [how to join relevant NCI projects](/getting_started/set_up_nci_account#join-relevant-nci-projects).
 
 
 - **NCI Account**<br> 

--- a/docs/models/run_a_model/run_access-om2.md
+++ b/docs/models/run_a_model/run_access-om2.md
@@ -21,7 +21,7 @@
 
 {{ model }} is an ocean-sea ice model. More information is available in the [{{ model }} overview][model configurations].
 
-The instructions below outline how to run {{ model }} using ACCESS-NRI's software deployment pipeline, specifically designed to run on the [National Computational Infrastructure (NCI)](https://nci.org.au/about-us/who-we-are) supercomputer [_Gadi_][gadi].
+The instructions below outline how to run {{ model }} using ACCESS-NRI's software deployment pipeline, specifically designed to run on [NCI](https://nci.org.au/about-us/who-we-are)'s supercomputer [_Gadi_][gadi].
 
 If you are unsure whether {{ model }} is the right choice for your experiment, take a look at the overview of [ACCESS Models](/models).
 

--- a/docs/models/run_a_model/run_access-om3.md
+++ b/docs/models/run_a_model/run_access-om3.md
@@ -28,7 +28,7 @@
 
 {{ model }} is an ocean-sea ice model. More information is available in the [{{ model }} overview][model configurations].
 
-The instructions below outline how to run {{ model }} using ACCESS-NRI's deployed software, on the [National Computational Infrastructure (NCI)](https://nci.org.au/about-us/who-we-are) supercomputer [_Gadi_][gadi].
+The instructions below outline how to run {{ model }} using ACCESS-NRI's deployed software, on on [NCI](https://nci.org.au/about-us/who-we-are)'s supercomputer [_Gadi_][gadi].
 
 If you are unsure whether {{ model }} is the right choice for your experiment, take a look at the overview of [ACCESS Models](/models).
 

--- a/docs/models/run_a_model/run_access-om3.md
+++ b/docs/models/run_a_model/run_access-om3.md
@@ -39,7 +39,7 @@ Detailed documentation on the configurations can be found in the [{{ model }} co
 ## Prerequisites
 
 !!! warning
-    To run {{ model }}, you need to be a member of a project with allocated _Service Units (SU)_. For more information, check [how to join relevant NCI projects](/getting_started/set_up_nci_account#join-relevant-nci-projects).
+    To run {{ model }}, you need to be a member of a project with allocated _SU_. For more information, check [how to join relevant NCI projects](/getting_started/set_up_nci_account#join-relevant-nci-projects).
 
 - **NCI Account**<br> 
     Before running {{ model }}, you need to [Set Up your NCI Account](/getting_started/set_up_nci_account).

--- a/docs/models/run_a_model/run_access-ram3.md
+++ b/docs/models/run_a_model/run_access-ram3.md
@@ -26,7 +26,7 @@
 
 ## About
 
-{{ model }} is an ACCESS-NRI-supported configuration of the [UK Met Office (UKMO)](https://www.metoffice.gov.uk/) Regional Nesting Suite for high-resolution regional atmosphere modelling. A description of the model and its components is available in the [{{ model }} overview]({{ access_models }}/#{{ model }}).
+{{ model }} is an ACCESS-NRI-supported configuration of the [UKMO](https://www.metoffice.gov.uk/) Regional Nesting Suite for high-resolution regional atmosphere modelling. A description of the model and its components is available in the [{{ model }} overview]({{ access_models }}/#{{ model }}).
 
 {{ model }} comprises multiple suites: the [Regional Ancillary Suite (RAS)](#ras) and [OSTIA Ancillary Suite (OAS)](#oas) that generate ancillary files (i.e., input files), and the [Regional Nesting Suite (RNS)](#rns) which runs the regional forecast.
 

--- a/docs/models/run_a_model/run_access-ram3.md
+++ b/docs/models/run_a_model/run_access-ram3.md
@@ -30,7 +30,7 @@
 
 {{ model }} comprises multiple suites: the [Regional Ancillary Suite (RAS)](#ras) and [OSTIA Ancillary Suite (OAS)](#oas) that generate ancillary files (i.e., input files), and the [Regional Nesting Suite (RNS)](#rns) which runs the regional forecast.
 
-The instructions below outline how to run {{ model }} using ACCESS-NRI's supported configuration, specifically designed to run on the [National Computational Infrastructure (NCI)](https://nci.org.au/about-us/who-we-are) supercomputer [_Gadi_][gadi]. The example experiment within this page focuses on a flood event in Lismore, NSW on 26 and 27 February 2022, using `BARRA` [land-surface initial conditions]({{ access_models }}/#land-surface-initial-conditions-source). For more details, see [Nesting configuration]({{ access_models }}/#nesting-configuration). 
+The instructions below outline how to run {{ model }} using ACCESS-NRI's supported configuration, specifically designed to run on [NCI](https://nci.org.au/about-us/who-we-are)'s supercomputer [_Gadi_][gadi]. The example experiment within this page focuses on a flood event in Lismore, NSW on 26 and 27 February 2022, using `BARRA` [land-surface initial conditions]({{ access_models }}/#land-surface-initial-conditions-source). For more details, see [Nesting configuration]({{ access_models }}/#nesting-configuration). 
 
 !!! tip 
     It is recommended to run the following example first without changes. Once you are comfortable with running the model, you can modify parameters such as domain position, dates, initial-conditions source, or output variables as needed.

--- a/drafts/configurations/access-am.md
+++ b/drafts/configurations/access-am.md
@@ -3,7 +3,7 @@
 
 <img src="../../../assets/model-config-logos/configurations-without-titles/access-am.png" alt="ACCESS AM model" class="white-background round-edges with-padding"></img>
 
-The ACCESS Atmosphere Model (ACCESS-AM) is a global model with atmosphere and land surface components. It is often used in Atmospheric Model Intercomparison Project (AMIP) experiments where it is driven by historically observed sea surface temperature and sea ice data.
+The ACCESS Atmosphere Model (ACCESS-AM) is a global model with atmosphere and land surface components. It is often used in AMIP experiments where it is driven by historically observed sea surface temperature and sea ice data.
 
 ACCESS-NRI will release supported ACCESS-AM configurations.  The first release, ACCESS-AM2, will be derived from the [CSIRO ACCESS-CM2 configuration](./access-cm.md#access-cm2) and will include [atmosphere] and [land] components.
 

--- a/drafts/med/model_evaluation_getting_started/index.md
+++ b/drafts/med/model_evaluation_getting_started/index.md
@@ -4,7 +4,7 @@
 
 ## What is MED?
 
-Model Evaluation and Diagnostics (MED) of ACCESS models includes:
+MED of ACCESS models includes:
 
 <ul>
   <li><b>Evaluation</b>

--- a/drafts/med/model_evaluation_getting_started/model_evaluation_getting_started.md
+++ b/drafts/med/model_evaluation_getting_started/model_evaluation_getting_started.md
@@ -101,7 +101,7 @@ For more information on running PBS jobs on <i>Gadi</i>, refer to <a href="https
 
 ## Running the `access-med` environment on ARE 
 
-NCI also supports an interactive coding environment called the Australian Research Environment (ARE). Its use is similar to submitting a PBS job via `qsub -I`, but with an added bonus of a dedicated graphical user interface for Jupyter notebooks. 
+NCI also supports an interactive coding environment called ARE. Its use is similar to submitting a PBS job via `qsub -I`, but with an added bonus of a dedicated graphical user interface for Jupyter notebooks. 
 <br>
 <br>
 For more information, check the <a href="/getting_started/are">Australian Research Environment (ARE) getting started</a>.

--- a/drafts/med/model_evaluation_getting_started/model_evaluation_getting_started.md
+++ b/drafts/med/model_evaluation_getting_started/model_evaluation_getting_started.md
@@ -2,7 +2,7 @@
 
 If you do not have `ssh` access to <i>Gadi</i>, refer to instructions on how to <a href="/getting_started/set_up_nci_account#login-to-gadi">login to Gadi</a>.
 
-The following instructions explain how to load the curated python environment on NCI, which includes packages and scripts supported by ACCESS-NRI. Once loaded, these can be run directly on <i>Gadi</i> via `ssh`, Portable Batch System (PBS) scripts, or in JupyterLab.
+The following instructions explain how to load the curated python environment on NCI, which includes packages and scripts supported by ACCESS-NRI. Once loaded, these can be run directly on <i>Gadi</i> via `ssh`, PBS scripts, or in JupyterLab.
 
 ???+ warning "ACCESS-NRI provides code and support, but not computing resources"
     You do not automatically have access to all `/g/data/` storage on <i>Gadi</i>. You need to <a href="/getting_started/set_up_nci_account#join-relevant-nci-projects">join an NCI project</a> to view files on `/g/data/$PROJECT`.

--- a/drafts/med/model_evaluation_recipe_gallery.md
+++ b/drafts/med/model_evaluation_recipe_gallery.md
@@ -2,7 +2,7 @@
 
 While we are still building this gallery, please have a look at the Community MED Recipes listed at <a href="../community_resources/community_med_recipes.md">Community Resources -> Community Model Evaluation Recipes</a> {{ community}}
 
-Here, we plan to provide you with an embedded link to our actively maintained Model Evaluation and Diagnostics (MED) Recipe Gallery, hosted at [medportal.herokuapp.com](https://medportal-dev-6a745f452687.herokuapp.com/papers/published). For now, we provide a placeholder image with link and pointers to useful MED resources.
+Here, we plan to provide you with an embedded link to our actively maintained MED Recipe Gallery, hosted at [medportal.herokuapp.com](https://medportal-dev-6a745f452687.herokuapp.com/papers/published). For now, we provide a placeholder image with link and pointers to useful MED resources.
 
 ## <a href="https://medportal-dev-6a745f452687.herokuapp.com/papers/published">Link to our MED Recipe Gallery</a>
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,6 +43,7 @@ theme:
     - content.code.annotate
     - content.action.edit
     - content.tabs.link
+    - content.tooltips
     - search.suggest
     - search.highlight
     - search.share
@@ -83,7 +84,9 @@ markdown_extensions:
   - pymdownx.caret
   - pymdownx.mark
   - pymdownx.tilde
-  - pymdownx.snippets
+  - pymdownx.snippets:
+      auto_append:
+        - abbreviations.md
   - pymdownx.highlight
   - pymdownx.tasklist:
       custom_checkbox: true
@@ -256,3 +259,4 @@ extra_javascript:
 watch:
   - mkdocs.yml
   - overrides/
+  - abbreviations.md


### PR DESCRIPTION
- [x] Added improved tooltips using mkdocs-material `content.tooltips` 
- [x] Updated `setUpPermalinks` JS function to retain mkdocs-material tooltip functionality
- [x] Added website-wide abbreviations in the `abbreviations.md` file, automatically added to all website pages.

As a consequence of the abbreviation set up, I changed all instances where specific abbreviations where fully expanded by replacing those with the sole abbreviation.

The abbreviations are rendered with a subtle underline (notice the **NCI** word in this paragraph):

<img width="1055" height="320" alt="Screenshot 2026-05-06 at 5 01 10 pm" src="https://github.com/user-attachments/assets/e0c0a45a-12db-4f95-84ff-cc53ad0601fe" />

And when hovered over, the tooltip with the explanation appears:

<img width="1055" height="320" alt="Screenshot 2026-05-06 at 5 01 20 pm" src="https://github.com/user-attachments/assets/631ca888-cbb5-42be-b8a4-1306c59a5b82" />


The abbreviations added are:
- ESM
- MOSRS
- CMIP
- HPC
- NCI
- ARE
- COSIMA
- UM
- SU
- MED
- AMIP
- ILAMB
- PBS


If you think other abbreviations should be added, feel free to comment with your suggestion.