### PR TITLE
Fix capitalization of NCI account heading

### DIFF
--- a/docs/getting_started/set_up_nci_account.md
+++ b/docs/getting_started/set_up_nci_account.md
@@ -1,4 +1,4 @@
-# Set Up your NCI Account
+# Set Up Your NCI Account
 
 The steps in this section are aimed at new users who would like to do any of the following tasks:
 


### PR DESCRIPTION
## Description

This pull request fixes the capitalization of the heading "Set Up Your NCI Account" on the Run a Model page.

Fixes #3

## Type of change

* [x] Bug fix (non-breaking change which fixes an issue, e.g. dead links)

## Checklist

* [x] The new content is accessible and located in the appropriate section
* [x] My changes do not break navigation and do not generate new warnings
* [x] I have checked that the links are valid and point to the intended content
* [x] I have checked my code/text and corrected any misspellings
