### PR TITLE
Fix capitalization typo in 'Run a Model page' 

### DIFF
--- a/docs/models/run_a_model/index.md
+++ b/docs/models/run_a_model/index.md
@@ -1,5 +1,5 @@
 # Run a Model
-These instructions are for running the ACCESS models on NCI. If you do not yet have an NCI account, please [Set Up your NCI Account](/getting_started/set_up_nci_account).
+These instructions are for running the ACCESS models on NCI. If you do not yet have an NCI account, please [set up your NCI account](/getting_started/set_up_nci_account).
 
 If you are unsure which ACCESS model is the best fit for your application, you can read more about each model on the [ACCESS Models page](/models/access_models).
 


### PR DESCRIPTION
# ACCESS-Hive Docs

Thank you for submitting a pull request to the ACCESS-Hive Docs Project. 🎉

More assistance is available in the [how to contribute section on ACCESS-Hive Docs](https://docs.access-hive.org.au/about/contribute/)

## Description

Fixes capitalization of "set up your NCI account" on [Run a Model page](https://docs.access-hive.org.au/models/run_a_model/)

Fixes #1223 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue, e.g. dead links)

## Checklist:

- [x] The new content is accessible and located in the appropriate section
- [x] My changes do not break navigation and do not generate new warnings
- [x] I have checked that the links are valid and point to the intended content
- [x] I have checked my code/text and corrected any misspellings

When your pull request is ready please [request a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review). 

Unless there is a specific person you want your PR to be reviewd by, please select the **Hive Docs Team**: `ACCESS-NRI/hivedocsteam`. This ensures the load for reviewing pull requests is shared equitably.
