### PR TITLE
Fix space missing in Code to run the ESM1.5 model

### DIFF
--- a/docs/models/run_a_model/run_access-esm.md
+++ b/docs/models/run_a_model/run_access-esm.md
@@ -378,7 +378,7 @@ Now some practical examples:
 - **Run 20 years of simulation with resubmission every 5 years**<br>
     To have a _total experiment length_ of 20 years with a 5-year resubmission cycle, leave [`runtime`](#runtime) as the default value of `1 year`, set `runspersub` to `5` and `walltime` to `10:00:00`. Then, run the configuration with `-n` set to `20`:
     ```
-    payu run-f -n 20
+    payu run -f -n 20
     ```
     This will submit subsequent jobs for the following years: 1 to 5, 6 to 10, 11 to 15, and 16 to 20, which is a total of 4 PBS jobs.
 


### PR DESCRIPTION
## Description

Fix space missing in Code to run the ESM1.5 model for the "Run 20 years of simulation with resubmission every 5 years" example.

Fixes #1231

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue, e.g. dead links)

## Checklist:

- [x] The new content is accessible and located in the appropriate section
- [x] My changes do not break navigation and do not generate new warnings
- [x] I have checked that the links are valid and point to the intended content
- [x] I have checked my code/text and corrected any misspellings
