### PR TITLE
Fix typo in the terminal code sample

### DIFF
--- a/docs/getting_started/set_up_nci_account.md
+++ b/docs/getting_started/set_up_nci_account.md
@@ -206,7 +206,7 @@ For example, if you want to change your default project to `tm70` on _Gadi_:
 <terminal-window>
     <terminal-line data="input">echo \$PROJECT</terminal-line>
     <terminal-line>&lt;old-default-project&gt;</terminal-line>
-    <terminal-line data="input">sed "s/\(PROJECT \)\w*/\1tm70/" ~/.config/gadi-login.conf</terminal-line>
+    <terminal-line data="input">sed -i "s/\(PROJECT \)\w*/\1tm70/" ~/.config/gadi-login.conf</terminal-line>
     <terminal-line data="input">exit</terminal-line>
     <terminal-line>logout</terminal-line>
     <terminal-line>Connection to gadi.nci.org.au closed.</terminal-line>


### PR DESCRIPTION

## Description

Fix typo in the terminal code sample in Set Up your NCI Account > [Change default project on Gadi](https://docs.access-hive.org.au/getting_started/set_up_nci_account/#change-default-project-on-gadi):

The command in the code line is correct, but the command in the terminal does not work, as it is missing an "-i". I added the missing "-i" in the terminal.

Fixes #1233

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue, e.g. dead links)

## Checklist:

- [x] The new content is accessible and located in the appropriate section
- [x] My changes do not break navigation and do not generate new warnings
- [x] I have checked that the links are valid and point to the intended content
- [x] I have checked my code/text and corrected any misspellings