### PR TITLE
Jasmeen/1219/fix homepage formatting

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,10 +1,13 @@
 ---
-hide:
-  - navigation
-  - toc
----
+# For home page, don't use standard layout box. 
+# Use custom layout as template, leaving out the 
+# top automatic title completely.
+template: home.html
 
-#
+hide:
+    - navigation        # hide left sidebar navigation
+    - toc               # hide right sidebar table of contents
+---
 
 <div class="introduction">
     <div>

--- a/overrides/home.html
+++ b/overrides/home.html
@@ -1,0 +1,7 @@
+{% extends "main.html" %}
+
+{% block content %}
+  <article class="md-content__inner md-typeset">
+    {{ page.content }}
+  </article>
+{% endblock %}

--- a/overrides/home.html
+++ b/overrides/home.html
@@ -1,7 +1,15 @@
+<!-- 
+    Reuse the default Material theme layout and only 
+    customise the page content.
+-->
 {% extends "main.html" %}
 
 {% block content %}
-  <article class="md-content__inner md-typeset">
-    {{ page.content }}
-  </article>
+    <!-- 
+        Display the main page without the automatic
+        heading added by the Material for MkDocs theme.
+    -->
+    <article class="md-content__inner md-typeset">
+        {{ page.content }}
+    </article>
 {% endblock %}


### PR DESCRIPTION
**Description:** 

Fixes issue #1219. 

This PR fixes the extra heading and blank space appearing at the top of the landing page. 

---

**Why:**

Material for MkDocs automatically adds heading at the top. Since the landing page does not have its own heading, the theme was displaying `Home` by default on top-left.

Adding an empty `#` heading removed the `Home` heading, but still left an unwanted blank line at the top of the page.

---

**Changes made:** 
This change is using a custom template to display the main page without the automatic heading added by the theme. This removes the need for the empty `#` heading and fixes the extra spacing at the top of the page.

- [x] Added a custom template that removes automatic heading by MkDocs theme.
- [x] Remove the empty `#` heading.
- [x] Remove extra blank space at the top of the page. 

---

Screenshots: 
<img width="1673" height="608" alt="Screenshot 2026-07-20 at 10 34 08" src="https://github.com/user-attachments/assets/5e1c917f-0549-4c45-ab1e-8fc7b3616600" />