### PR TITLE
Update run_access-om3.md - fix broken link

### DIFF
--- a/docs/models/run_a_model/run_access-om3.md
+++ b/docs/models/run_a_model/run_access-om3.md
@@ -332,7 +332,7 @@ parts, some of which it is more likely will need modification, and others which 
 rarely changed.
 
 More details on model and _payu_ configuration specific to {{ model }} are found in the 
-[Configurations Overview](https://access-om3-configs.access-hive.org.au/configurations/Overview/) 
+[Configurations Overview](https://access-om3-configs.access-hive.org.au/latest/configurations/Overview/) 
 section of {{ model }} configs documentation. For more general information on _payu_ configuration, 
 refer to [how to configure your experiment with payu](https://payu.readthedocs.io/en/latest/config.html).
 


### PR DESCRIPTION
## Description
Updated Configurations Overview hyperlink to the correct link.

Fixes #1249 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue, e.g. dead links)

## Checklist:

- [x] The new content is accessible and located in the appropriate section
- [x] My changes do not break navigation and do not generate new warnings
- [x] I have checked that the links are valid and point to the intended content
- [x] I have checked my code/text and corrected any misspellings

<!-- readthedocs-preview access-hive-docs start -->
---
:books: PR Preview :link: --> https://access-hive-docs--1250.org.readthedocs.build/

<!-- readthedocs-preview access-hive-docs end -->